### PR TITLE
Use /proc/self on Linux for Self()

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -30,8 +30,9 @@ type HostProvider interface {
 }
 
 type ProcessProvider interface {
-	Process(pid int) (types.Process, error)
 	Processes() ([]types.Process, error)
+	Process(pid int) (types.Process, error)
+	Self() (types.Process, error)
 }
 
 func Register(provider interface{}) {

--- a/providers/darwin/process_darwin_amd64.go
+++ b/providers/darwin/process_darwin_amd64.go
@@ -24,6 +24,7 @@ import "C"
 import (
 	"bytes"
 	"encoding/binary"
+	"os"
 	"time"
 	"unsafe"
 
@@ -42,6 +43,10 @@ func (s darwinSystem) Process(pid int) (types.Process, error) {
 	p := process{pid: pid}
 
 	return &p, nil
+}
+
+func (s darwinSystem) Self() (types.Process, error) {
+	return s.Process(os.Getpid())
 }
 
 type process struct {

--- a/providers/linux/process_linux.go
+++ b/providers/linux/process_linux.go
@@ -52,6 +52,15 @@ func (s linuxSystem) Process(pid int) (types.Process, error) {
 	return &process{Proc: proc, fs: s.procFS}, nil
 }
 
+func (s linuxSystem) Self() (types.Process, error) {
+	proc, err := s.procFS.Self()
+	if err != nil {
+		return nil, err
+	}
+
+	return &process{Proc: proc, fs: s.procFS}, nil
+}
+
 type process struct {
 	procfs.Proc
 	fs   procfs.FS

--- a/system.go
+++ b/system.go
@@ -15,7 +15,6 @@
 package system
 
 import (
-	"os"
 	"runtime"
 
 	"github.com/elastic/go-sysinfo/internal/registry"
@@ -75,5 +74,9 @@ func Processes() ([]types.Process, error) {
 // information collection is not implemented for this platform then
 // types.ErrNotImplemented is returned.
 func Self() (types.Process, error) {
-	return Process(os.Getpid())
+	provider := registry.GetProcessProvider()
+	if provider == nil {
+		return nil, types.ErrNotImplemented
+	}
+	return provider.Self()
 }


### PR DESCRIPTION
By using `/proc/self `instead of `/proc/$(os.Getpid()}` we can prevent issues related to PID namespacing. Issues can occur when operating in a container, the host machines proc filesystem is mounted  inside the container, and go-sysinfo is configured to read from that other proc FS.

More changes are going to be needed to be able to configure the mount point for the proc file-system. And we will ensure that it is not configured on a global basis.