### PR TITLE
Aling go-sysinfo json output with ECS

### DIFF
--- a/types/host.go
+++ b/types/host.go
@@ -29,10 +29,10 @@ type HostInfo struct {
 	Architecture      string    `json:"architecture"`            // Hardware architecture (e.g. x86_64, arm, ppc, mips).
 	BootTime          time.Time `json:"boot_time"`               // Host boot time.
 	Containerized     *bool     `json:"containerized,omitempty"` // Is the process containerized.
-	Hostname          string    `json:"hostname"`                // Hostname
-	IPs               []string  `json:"ips,omitempty"`           // List of all IPs.
+	Hostname          string    `json:"name"`                    // Hostname
+	IPs               []string  `json:"ip,omitempty"`            // List of all IPs.
 	KernelVersion     string    `json:"kernel_version"`          // Kernel version.
-	MACs              []string  `json:"mac_addresses"`           // List of MAC addresses.
+	MACs              []string  `json:"mac"`                     // List of MAC addresses.
 	OS                *OSInfo   `json:"os"`                      // OS information.
 	Timezone          string    `json:"timezone"`                // System timezone.
 	TimezoneOffsetSec int       `json:"timezone_offset_sec"`     // Timezone offset (seconds from UTC).


### PR DESCRIPTION
* Change `host.hostname` to `host.name`
* Change `host.ips` to `host.ip`
* Change `host.mac_addresses` to `host.mac`

The names of the variables were not changed but the JSON output was modified.

See https://github.com/elastic/ecs#host for ECS host fields.