### PR TITLE
Drop Timestamp field from samples

### DIFF
--- a/providers/darwin/host_darwin_amd64.go
+++ b/providers/darwin/host_darwin_amd64.go
@@ -58,16 +58,15 @@ func (h *host) CPUTime() (*types.CPUTimes, error) {
 	ticksPerSecond := time.Duration(getClockTicks())
 
 	return &types.CPUTimes{
-		Timestamp: time.Now(),
-		User:      time.Duration(cpu.User) * time.Second / ticksPerSecond,
-		System:    time.Duration(cpu.System) * time.Second / ticksPerSecond,
-		Idle:      time.Duration(cpu.Idle) * time.Second / ticksPerSecond,
-		Nice:      time.Duration(cpu.Nice) * time.Second / ticksPerSecond,
+		User:   time.Duration(cpu.User) * time.Second / ticksPerSecond,
+		System: time.Duration(cpu.System) * time.Second / ticksPerSecond,
+		Idle:   time.Duration(cpu.Idle) * time.Second / ticksPerSecond,
+		Nice:   time.Duration(cpu.Nice) * time.Second / ticksPerSecond,
 	}, nil
 }
 
 func (h *host) Memory() (*types.HostMemoryInfo, error) {
-	mem := &types.HostMemoryInfo{Timestamp: time.Now()}
+	var mem types.HostMemoryInfo
 
 	// Total physical memory.
 	if err := sysctlByName("hw.memsize", &mem.Total); err != nil {
@@ -127,7 +126,7 @@ func (h *host) Memory() (*types.HostMemoryInfo, error) {
 	mem.VirtualUsed = swap.Used
 	mem.VirtualFree = swap.Available
 
-	return mem, nil
+	return &mem, nil
 }
 
 func newHost() (*host, error) {

--- a/providers/darwin/process_darwin_amd64.go
+++ b/providers/darwin/process_darwin_amd64.go
@@ -93,17 +93,15 @@ func (p *process) Environment() (map[string]string, error) {
 
 func (p *process) CPUTime() types.CPUTimes {
 	return types.CPUTimes{
-		Timestamp: time.Now(),
-		User:      time.Duration(p.task.Ptinfo.Total_user),
-		System:    time.Duration(p.task.Ptinfo.Total_system),
+		User:   time.Duration(p.task.Ptinfo.Total_user),
+		System: time.Duration(p.task.Ptinfo.Total_system),
 	}
 }
 
 func (p *process) Memory() types.MemoryInfo {
 	return types.MemoryInfo{
-		Timestamp: time.Now(),
-		Virtual:   p.task.Ptinfo.Virtual_size,
-		Resident:  p.task.Ptinfo.Resident_size,
+		Virtual:  p.task.Ptinfo.Virtual_size,
+		Resident: p.task.Ptinfo.Resident_size,
 		Metrics: map[string]uint64{
 			"page_ins":    uint64(p.task.Ptinfo.Pageins),
 			"page_faults": uint64(p.task.Ptinfo.Faults),

--- a/providers/linux/host_linux.go
+++ b/providers/linux/host_linux.go
@@ -76,15 +76,14 @@ func (h *host) CPUTime() (*types.CPUTimes, error) {
 	}
 
 	return &types.CPUTimes{
-		Timestamp: time.Now(),
-		User:      time.Duration(stat.CPUTotal.User * float64(time.Second)),
-		System:    time.Duration(stat.CPUTotal.System * float64(time.Second)),
-		Idle:      time.Duration(stat.CPUTotal.Idle * float64(time.Second)),
-		IOWait:    time.Duration(stat.CPUTotal.Iowait * float64(time.Second)),
-		IRQ:       time.Duration(stat.CPUTotal.IRQ * float64(time.Second)),
-		Nice:      time.Duration(stat.CPUTotal.Nice * float64(time.Second)),
-		SoftIRQ:   time.Duration(stat.CPUTotal.SoftIRQ * float64(time.Second)),
-		Steal:     time.Duration(stat.CPUTotal.Steal * float64(time.Second)),
+		User:    time.Duration(stat.CPUTotal.User * float64(time.Second)),
+		System:  time.Duration(stat.CPUTotal.System * float64(time.Second)),
+		Idle:    time.Duration(stat.CPUTotal.Idle * float64(time.Second)),
+		IOWait:  time.Duration(stat.CPUTotal.Iowait * float64(time.Second)),
+		IRQ:     time.Duration(stat.CPUTotal.IRQ * float64(time.Second)),
+		Nice:    time.Duration(stat.CPUTotal.Nice * float64(time.Second)),
+		SoftIRQ: time.Duration(stat.CPUTotal.SoftIRQ * float64(time.Second)),
+		Steal:   time.Duration(stat.CPUTotal.Steal * float64(time.Second)),
 	}, nil
 }
 

--- a/providers/linux/host_linux_test.go
+++ b/providers/linux/host_linux_test.go
@@ -20,7 +20,6 @@ package linux
 import (
 	"encoding/json"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -50,7 +49,6 @@ func TestHostMemoryInfo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.WithinDuration(t, time.Now(), m.Timestamp, time.Minute)
 	assert.EqualValues(t, 4139057152, m.Total)
 	assert.NotContains(t, m.Metrics, "MemTotal")
 	assert.Contains(t, m.Metrics, "Slab")

--- a/providers/linux/memory_linux.go
+++ b/providers/linux/memory_linux.go
@@ -20,7 +20,6 @@ package linux
 import (
 	"bytes"
 	"strconv"
-	"time"
 
 	"github.com/pkg/errors"
 
@@ -29,8 +28,7 @@ import (
 
 func parseMemInfo(content []byte) (*types.HostMemoryInfo, error) {
 	memInfo := &types.HostMemoryInfo{
-		Timestamp: time.Now().UTC(),
-		Metrics:   map[string]uint64{},
+		Metrics: map[string]uint64{},
 	}
 
 	hasAvailable := false

--- a/providers/linux/process_linux.go
+++ b/providers/linux/process_linux.go
@@ -133,9 +133,8 @@ func (p *process) Memory() types.MemoryInfo {
 	}
 
 	return types.MemoryInfo{
-		Timestamp: time.Now(),
-		Resident:  uint64(stat.ResidentMemory()),
-		Virtual:   uint64(stat.VirtualMemory()),
+		Resident: uint64(stat.ResidentMemory()),
+		Virtual:  uint64(stat.VirtualMemory()),
 	}
 }
 
@@ -146,9 +145,8 @@ func (p *process) CPUTime() types.CPUTimes {
 	}
 
 	return types.CPUTimes{
-		Timestamp: time.Now(),
-		User:      ticksToDuration(uint64(stat.UTime)),
-		System:    ticksToDuration(uint64(stat.STime)),
+		User:   ticksToDuration(uint64(stat.UTime)),
+		System: ticksToDuration(uint64(stat.STime)),
 	}
 }
 

--- a/providers/windows/host_windows.go
+++ b/providers/windows/host_windows.go
@@ -55,10 +55,9 @@ func (h *host) CPUTime() (*types.CPUTimes, error) {
 	}
 
 	return &types.CPUTimes{
-		Timestamp: time.Now(),
-		System:    kernel,
-		User:      user,
-		Idle:      idle,
+		System: kernel,
+		User:   user,
+		Idle:   idle,
 	}, nil
 }
 
@@ -69,7 +68,6 @@ func (h *host) Memory() (*types.HostMemoryInfo, error) {
 	}
 
 	return &types.HostMemoryInfo{
-		Timestamp:    time.Now(),
 		Total:        mem.TotalPhys,
 		Used:         mem.TotalPhys - mem.AvailPhys,
 		Free:         mem.AvailPhys,

--- a/types/host.go
+++ b/types/host.go
@@ -67,7 +67,6 @@ type LoadAverageInfo struct {
 
 // HostMemoryInfo (all values are specified in bytes).
 type HostMemoryInfo struct {
-	Timestamp    time.Time         `json:"timestamp"`           // Time at which samples were collected.
 	Total        uint64            `json:"total_bytes"`         // Total physical memory.
 	Used         uint64            `json:"used_bytes"`          // Total - Free
 	Available    uint64            `json:"available_bytes"`     // Amount of memory available without swapping.

--- a/types/process.go
+++ b/types/process.go
@@ -51,15 +51,14 @@ type Memory interface {
 }
 
 type CPUTimes struct {
-	Timestamp time.Time     `json:"timestamp"` // Time at which samples were collected.
-	User      time.Duration `json:"user"`
-	System    time.Duration `json:"system"`
-	Idle      time.Duration `json:"idle,omitempty"`
-	IOWait    time.Duration `json:"iowait,omitempty"`
-	IRQ       time.Duration `json:"irq,omitempty"`
-	Nice      time.Duration `json:"nice,omitempty"`
-	SoftIRQ   time.Duration `json:"soft_irq,omitempty"`
-	Steal     time.Duration `json:"steal,omitempty"`
+	User    time.Duration `json:"user"`
+	System  time.Duration `json:"system"`
+	Idle    time.Duration `json:"idle,omitempty"`
+	IOWait  time.Duration `json:"iowait,omitempty"`
+	IRQ     time.Duration `json:"irq,omitempty"`
+	Nice    time.Duration `json:"nice,omitempty"`
+	SoftIRQ time.Duration `json:"soft_irq,omitempty"`
+	Steal   time.Duration `json:"steal,omitempty"`
 }
 
 func (cpu CPUTimes) Total() time.Duration {
@@ -68,10 +67,9 @@ func (cpu CPUTimes) Total() time.Duration {
 }
 
 type MemoryInfo struct {
-	Timestamp time.Time         `json:"timestamp"` // Time at which samples were collected.
-	Resident  uint64            `json:"resident_bytes"`
-	Virtual   uint64            `json:"virtual_bytes"`
-	Metrics   map[string]uint64 `json:"raw,omitempty"` // Other memory related metrics.
+	Resident uint64            `json:"resident_bytes"`
+	Virtual  uint64            `json:"virtual_bytes"`
+	Metrics  map[string]uint64 `json:"raw,omitempty"` // Other memory related metrics.
 }
 
 type SeccompInfo struct {


### PR DESCRIPTION
Timestamps aren't strictly necessary
here, so they're just adding overhead
for some consumers. Those that require
them should embed the structs, and
take the timestamp before/after as
appropriate.

Closes #16 