### PR TITLE
 Unified CPUTimer interface

### DIFF
--- a/providers/darwin/host_darwin_amd64.go
+++ b/providers/darwin/host_darwin_amd64.go
@@ -49,15 +49,15 @@ func (h *host) Info() types.HostInfo {
 	return h.info
 }
 
-func (h *host) CPUTime() (*types.CPUTimes, error) {
+func (h *host) CPUTime() (types.CPUTimes, error) {
 	cpu, err := getHostCPULoadInfo()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get host CPU usage")
+		return types.CPUTimes{}, errors.Wrap(err, "failed to get host CPU usage")
 	}
 
 	ticksPerSecond := time.Duration(getClockTicks())
 
-	return &types.CPUTimes{
+	return types.CPUTimes{
 		User:   time.Duration(cpu.User) * time.Second / ticksPerSecond,
 		System: time.Duration(cpu.System) * time.Second / ticksPerSecond,
 		Idle:   time.Duration(cpu.Idle) * time.Second / ticksPerSecond,

--- a/providers/darwin/process_darwin_amd64.go
+++ b/providers/darwin/process_darwin_amd64.go
@@ -91,14 +91,18 @@ func (p *process) Environment() (map[string]string, error) {
 	return p.env, nil
 }
 
-func (p *process) CPUTime() types.CPUTimes {
+func (p *process) CPUTime() (types.CPUTimes, error) {
+	// TODO p.task is unset until Info() returns successfully.
+	// Should this be getting its own process info, like on Linux?
 	return types.CPUTimes{
 		User:   time.Duration(p.task.Ptinfo.Total_user),
 		System: time.Duration(p.task.Ptinfo.Total_system),
-	}
+	}, nil
 }
 
-func (p *process) Memory() types.MemoryInfo {
+func (p *process) Memory() (types.MemoryInfo, error) {
+	// TODO p.task is unset until Info() returns successfully.
+	// Should this be getting its own process info, like on Linux?
 	return types.MemoryInfo{
 		Virtual:  p.task.Ptinfo.Virtual_size,
 		Resident: p.task.Ptinfo.Resident_size,
@@ -106,7 +110,7 @@ func (p *process) Memory() types.MemoryInfo {
 			"page_ins":    uint64(p.task.Ptinfo.Pageins),
 			"page_faults": uint64(p.task.Ptinfo.Faults),
 		},
-	}
+	}, nil
 }
 
 func getProcTaskAllInfo(pid int, info *procTaskAllInfo) error {

--- a/providers/darwin/process_darwin_amd64_test.go
+++ b/providers/darwin/process_darwin_amd64_test.go
@@ -26,10 +26,14 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/go-sysinfo/internal/registry"
+	"github.com/elastic/go-sysinfo/types"
 )
 
 var _ registry.HostProvider = darwinSystem{}
 var _ registry.ProcessProvider = darwinSystem{}
+
+var _ types.CPUTimer = (*process)(nil)
+var _ types.Memory = (*process)(nil)
 
 func TestKernProcInfo(t *testing.T) {
 	var p process

--- a/providers/linux/host_linux.go
+++ b/providers/linux/host_linux.go
@@ -69,13 +69,13 @@ func (h *host) Memory() (*types.HostMemoryInfo, error) {
 	return parseMemInfo(content)
 }
 
-func (h *host) CPUTime() (*types.CPUTimes, error) {
+func (h *host) CPUTime() (types.CPUTimes, error) {
 	stat, err := h.procFS.NewStat()
 	if err != nil {
-		return nil, err
+		return types.CPUTimes{}, err
 	}
 
-	return &types.CPUTimes{
+	return types.CPUTimes{
 		User:    time.Duration(stat.CPUTotal.User * float64(time.Second)),
 		System:  time.Duration(stat.CPUTotal.System * float64(time.Second)),
 		Idle:    time.Duration(stat.CPUTotal.Idle * float64(time.Second)),

--- a/providers/linux/process_linux.go
+++ b/providers/linux/process_linux.go
@@ -126,28 +126,28 @@ func (p *process) Info() (types.ProcessInfo, error) {
 	return *p.info, nil
 }
 
-func (p *process) Memory() types.MemoryInfo {
+func (p *process) Memory() (types.MemoryInfo, error) {
 	stat, err := p.NewStat()
 	if err != nil {
-		return types.MemoryInfo{}
+		return types.MemoryInfo{}, err
 	}
 
 	return types.MemoryInfo{
 		Resident: uint64(stat.ResidentMemory()),
 		Virtual:  uint64(stat.VirtualMemory()),
-	}
+	}, nil
 }
 
-func (p *process) CPUTime() types.CPUTimes {
+func (p *process) CPUTime() (types.CPUTimes, error) {
 	stat, err := p.NewStat()
 	if err != nil {
-		return types.CPUTimes{}
+		return types.CPUTimes{}, err
 	}
 
 	return types.CPUTimes{
 		User:   ticksToDuration(uint64(stat.UTime)),
 		System: ticksToDuration(uint64(stat.STime)),
-	}
+	}, nil
 }
 
 func (p *process) FileDescriptors() ([]string, error) {

--- a/providers/linux/process_linux_test.go
+++ b/providers/linux/process_linux_test.go
@@ -17,7 +17,13 @@
 
 package linux
 
-import "github.com/elastic/go-sysinfo/internal/registry"
+import (
+	"github.com/elastic/go-sysinfo/internal/registry"
+	"github.com/elastic/go-sysinfo/types"
+)
 
 var _ registry.HostProvider = linuxSystem{}
 var _ registry.ProcessProvider = linuxSystem{}
+
+var _ types.CPUTimer = (*process)(nil)
+var _ types.Memory = (*process)(nil)

--- a/providers/windows/host_windows.go
+++ b/providers/windows/host_windows.go
@@ -48,13 +48,13 @@ func (h *host) Info() types.HostInfo {
 	return h.info
 }
 
-func (h *host) CPUTime() (*types.CPUTimes, error) {
+func (h *host) CPUTime() (types.CPUTimes, error) {
 	idle, kernel, user, err := windows.GetSystemTimes()
 	if err != nil {
-		return nil, err
+		return types.CPUTimes{}, err
 	}
 
-	return &types.CPUTimes{
+	return types.CPUTimes{
 		System: kernel,
 		User:   user,
 		Idle:   idle,

--- a/system_test.go
+++ b/system_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/go-sysinfo/types"
 )
@@ -146,14 +147,16 @@ func TestSelf(t *testing.T) {
 	}
 
 	if v, ok := process.(types.Memory); ok {
-		memInfo := v.Memory()
+		memInfo, err := v.Memory()
+		require.NoError(t, err)
 		assert.NotZero(t, memInfo.Virtual)
 		assert.NotZero(t, memInfo.Resident)
 		output["process.mem"] = memInfo
 	}
 
 	if v, ok := process.(types.CPUTimer); ok {
-		cpuTimes := v.CPUTime()
+		cpuTimes, err := v.CPUTime()
+		require.NoError(t, err)
 		assert.NotZero(t, cpuTimes)
 		output["process.cpu"] = cpuTimes
 	}

--- a/types/host.go
+++ b/types/host.go
@@ -20,9 +20,9 @@ package types
 import "time"
 
 type Host interface {
+	CPUTimer
 	Info() HostInfo
 	Memory() (*HostMemoryInfo, error)
-	CPUTime() (*CPUTimes, error)
 }
 
 type HostInfo struct {

--- a/types/process.go
+++ b/types/process.go
@@ -43,11 +43,17 @@ type FileDescriptor interface {
 }
 
 type CPUTimer interface {
-	CPUTime() CPUTimes
+	// CPUTime returns a CPUTimes structure for
+	// the host or some process.
+	//
+	// The User and System fields are guaranteed
+	// to be populated for all platforms, and
+	// for both hosts and processes.
+	CPUTime() (CPUTimes, error)
 }
 
 type Memory interface {
-	Memory() MemoryInfo
+	Memory() (MemoryInfo, error)
 }
 
 type CPUTimes struct {


### PR DESCRIPTION
Change CPUTimer interface such that it matches
Host's CPUTime signature, and modify the existing
Process implementations to match.

Also, stop swallowing errors in Process.CPUTime
and Process.Memory. The latter involves also changing
types.Memory's method signature to return an error.

Closes #17 
Closes #18