### PR TITLE
 provider/windows: minimal process provider

### DIFF
--- a/providers/darwin/process_darwin_amd64_test.go
+++ b/providers/darwin/process_darwin_amd64_test.go
@@ -26,14 +26,10 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/go-sysinfo/internal/registry"
-	"github.com/elastic/go-sysinfo/types"
 )
 
 var _ registry.HostProvider = darwinSystem{}
 var _ registry.ProcessProvider = darwinSystem{}
-
-var _ types.CPUTimer = (*process)(nil)
-var _ types.Memory = (*process)(nil)
 
 func TestKernProcInfo(t *testing.T) {
 	var p process

--- a/providers/linux/process_linux_test.go
+++ b/providers/linux/process_linux_test.go
@@ -19,11 +19,7 @@ package linux
 
 import (
 	"github.com/elastic/go-sysinfo/internal/registry"
-	"github.com/elastic/go-sysinfo/types"
 )
 
 var _ registry.HostProvider = linuxSystem{}
 var _ registry.ProcessProvider = linuxSystem{}
-
-var _ types.CPUTimer = (*process)(nil)
-var _ types.Memory = (*process)(nil)

--- a/providers/windows/process_windows.go
+++ b/providers/windows/process_windows.go
@@ -1,0 +1,148 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package windows
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/elastic/go-sysinfo/types"
+	"github.com/elastic/go-windows"
+)
+
+var (
+	selfPID = os.Getpid()
+)
+
+func (s windowsSystem) Processes() ([]types.Process, error) {
+	return nil, types.ErrNotImplemented
+}
+
+func (s windowsSystem) Process(pid int) (types.Process, error) {
+	if pid == selfPID {
+		return s.Self()
+	}
+	// TODO implement support for enumerating processes.
+	return nil, types.ErrNotImplemented
+}
+
+func (s windowsSystem) Self() (types.Process, error) {
+	return newProcess(selfPID)
+}
+
+type process struct {
+	pid  int
+	info types.ProcessInfo
+}
+
+func newProcess(pid int) (*process, error) {
+	p := &process{pid: pid}
+	if err := p.init(); err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+func (p *process) init() error {
+	if p.pid != selfPID {
+		// TODO implement support for other processes.
+		return types.ErrNotImplemented
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		return err
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	handle, err := p.open()
+	if err != nil {
+		return err
+	}
+	defer syscall.CloseHandle(handle)
+
+	var creationTime, exitTime, kernelTime, userTime syscall.Filetime
+	if err := syscall.GetProcessTimes(handle, &creationTime, &exitTime, &kernelTime, &userTime); err != nil {
+		return err
+	}
+
+	p.info = types.ProcessInfo{
+		Name:      filepath.Base(exe),
+		PID:       selfPID,
+		PPID:      os.Getppid(),
+		CWD:       cwd,
+		Exe:       exe,
+		Args:      os.Args[:],
+		StartTime: time.Unix(0, creationTime.Nanoseconds()),
+	}
+	return nil
+}
+
+func (p *process) open() (syscall.Handle, error) {
+	if p.pid != selfPID {
+		// TODO implement support for other processes.
+		return 0, types.ErrNotImplemented
+	}
+	return syscall.GetCurrentProcess()
+}
+
+func (p *process) Info() (types.ProcessInfo, error) {
+	return p.info, nil
+}
+
+func (p *process) Memory() (types.MemoryInfo, error) {
+	handle, err := p.open()
+	if err != nil {
+		return types.MemoryInfo{}, err
+	}
+	defer syscall.CloseHandle(handle)
+
+	counters, err := windows.GetProcessMemoryInfo(handle)
+	if err != nil {
+		return types.MemoryInfo{}, err
+	}
+
+	return types.MemoryInfo{
+		Resident: uint64(counters.WorkingSetSize),
+		Virtual:  uint64(counters.PrivateUsage),
+	}, nil
+}
+
+func (p *process) CPUTime() (types.CPUTimes, error) {
+	handle, err := p.open()
+	if err != nil {
+		return types.CPUTimes{}, err
+	}
+	defer syscall.CloseHandle(handle)
+
+	var creationTime, exitTime, kernelTime, userTime syscall.Filetime
+	if err := syscall.GetProcessTimes(handle, &creationTime, &exitTime, &kernelTime, &userTime); err != nil {
+		return types.CPUTimes{}, err
+	}
+
+	return types.CPUTimes{
+		User:   windows.FiletimeToDuration(&userTime),
+		System: windows.FiletimeToDuration(&kernelTime),
+	}, nil
+}

--- a/providers/windows/process_windows.go
+++ b/providers/windows/process_windows.go
@@ -23,8 +23,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/elastic/go-sysinfo/types"
 	"github.com/elastic/go-windows"
+
+	"github.com/elastic/go-sysinfo/types"
 )
 
 var (

--- a/providers/windows/process_windows_test.go
+++ b/providers/windows/process_windows_test.go
@@ -19,11 +19,7 @@ package windows
 
 import (
 	"github.com/elastic/go-sysinfo/internal/registry"
-	"github.com/elastic/go-sysinfo/types"
 )
 
 var _ registry.HostProvider = windowsSystem{}
 var _ registry.ProcessProvider = windowsSystem{}
-
-var _ types.CPUTimer = (*process)(nil)
-var _ types.Memory = (*process)(nil)

--- a/providers/windows/process_windows_test.go
+++ b/providers/windows/process_windows_test.go
@@ -1,0 +1,29 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package windows
+
+import (
+	"github.com/elastic/go-sysinfo/internal/registry"
+	"github.com/elastic/go-sysinfo/types"
+)
+
+var _ registry.HostProvider = windowsSystem{}
+var _ registry.ProcessProvider = windowsSystem{}
+
+var _ types.CPUTimer = (*process)(nil)
+var _ types.Memory = (*process)(nil)

--- a/system_test.go
+++ b/system_test.go
@@ -35,8 +35,6 @@ type ProcessFeatures struct {
 	ProcessInfo    bool
 	Environment    bool
 	FileDescriptor bool
-	CPUTimer       bool
-	Memory         bool
 	Seccomp        bool
 	Capabilities   bool
 }
@@ -46,15 +44,11 @@ var expectedProcessFeatures = map[string]*ProcessFeatures{
 		ProcessInfo:    true,
 		Environment:    true,
 		FileDescriptor: false,
-		CPUTimer:       true,
-		Memory:         true,
 	},
 	"linux": &ProcessFeatures{
 		ProcessInfo:    true,
 		Environment:    true,
 		FileDescriptor: true,
-		CPUTimer:       true,
-		Memory:         true,
 		Seccomp:        true,
 		Capabilities:   true,
 	},
@@ -75,8 +69,6 @@ func TestProcessFeaturesMatrix(t *testing.T) {
 
 	_, features.Environment = process.(types.Environment)
 	_, features.FileDescriptor = process.(types.FileDescriptor)
-	_, features.CPUTimer = process.(types.CPUTimer)
-	_, features.Memory = process.(types.Memory)
 	_, features.Seccomp = process.(types.Seccomp)
 	_, features.Capabilities = process.(types.Capabilities)
 
@@ -146,13 +138,11 @@ func TestSelf(t *testing.T) {
 		output["process.env"] = actualEnv
 	}
 
-	if v, ok := process.(types.Memory); ok {
-		memInfo, err := v.Memory()
-		require.NoError(t, err)
-		assert.NotZero(t, memInfo.Virtual)
-		assert.NotZero(t, memInfo.Resident)
-		output["process.mem"] = memInfo
-	}
+	memInfo, err := process.Memory()
+	require.NoError(t, err)
+	assert.NotZero(t, memInfo.Virtual)
+	assert.NotZero(t, memInfo.Resident)
+	output["process.mem"] = memInfo
 
 	if v, ok := process.(types.CPUTimer); ok {
 		cpuTimes, err := v.CPUTime()

--- a/types/process.go
+++ b/types/process.go
@@ -20,7 +20,9 @@ package types
 import "time"
 
 type Process interface {
+	CPUTimer
 	Info() (ProcessInfo, error)
+	Memory() (MemoryInfo, error)
 }
 
 type ProcessInfo struct {
@@ -50,10 +52,6 @@ type CPUTimer interface {
 	// to be populated for all platforms, and
 	// for both hosts and processes.
 	CPUTime() (CPUTimes, error)
-}
-
-type Memory interface {
-	Memory() (MemoryInfo, error)
 }
 
 type CPUTimes struct {

--- a/vendor/github.com/elastic/go-windows/CHANGELOG.md
+++ b/vendor/github.com/elastic/go-windows/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+* Add GetProcessMemoryInfo: [#2](https://github.com/elastic/go-windows/pull/2)

--- a/vendor/github.com/elastic/go-windows/LICENSE.txt
+++ b/vendor/github.com/elastic/go-windows/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/elastic/go-windows/NOTICE.txt
+++ b/vendor/github.com/elastic/go-windows/NOTICE.txt
@@ -1,0 +1,5 @@
+Elastic go-windows
+Copyright 2017-2018 Elasticsearch B.V.
+
+This product includes software developed at
+Elasticsearch, B.V. (https://www.elastic.co/).

--- a/vendor/github.com/elastic/go-windows/doc.go
+++ b/vendor/github.com/elastic/go-windows/doc.go
@@ -1,20 +1,23 @@
-// Copyright 2018 Elasticsearch Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
 // http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 // Package windows contains various Windows system calls.
 package windows
 
 // Use "GOOS=windows go generate -v -x" to generate the sources.
 // Add -trace to enable debug prints around syscalls.
-//go:generate go run $GOROOT/src/syscall/mksyscall_windows.go -systemdll=false -output zsyscall_windows.go kernel32.go version.go
+//go:generate go run $GOROOT/src/syscall/mksyscall_windows.go -systemdll=false -output zsyscall_windows.go kernel32.go version.go psapi.go

--- a/vendor/github.com/elastic/go-windows/kernel32.go
+++ b/vendor/github.com/elastic/go-windows/kernel32.go
@@ -1,16 +1,19 @@
-// Copyright 2018 Elasticsearch Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
 // http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 // +build windows
 

--- a/vendor/github.com/elastic/go-windows/psapi.go
+++ b/vendor/github.com/elastic/go-windows/psapi.go
@@ -1,0 +1,62 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build windows
+
+package windows
+
+import (
+	"syscall"
+	"unsafe"
+
+	"github.com/pkg/errors"
+)
+
+// Syscalls
+//sys   _GetProcessMemoryInfo(handle syscall.Handle, psmemCounters *ProcessMemoryCountersEx, cb uint32) (err error) = psapi.GetProcessMemoryInfo
+
+var (
+	sizeofProcessMemoryCountersEx = uint32(unsafe.Sizeof(ProcessMemoryCountersEx{}))
+)
+
+// ProcessMemoryCountersEx is an equivalent representation of
+// PROCESS_MEMORY_COUNTERS_EX in the Windows API. It contains information about
+// the memory usage of a process.
+// https://docs.microsoft.com/en-au/windows/desktop/api/psapi/ns-psapi-_process_memory_counters_ex
+type ProcessMemoryCountersEx struct {
+	cb                         uint32
+	PageFaultCount             uint32
+	PeakWorkingSetSize         uintptr
+	WorkingSetSize             uintptr
+	QuotaPeakPagedPoolUsage    uintptr
+	QuotaPagedPoolUsage        uintptr
+	QuotaPeakNonPagedPoolUsage uintptr
+	QuotaNonPagedPoolUsage     uintptr
+	PagefileUsage              uintptr
+	PeakPagefileUsage          uintptr
+	PrivateUsage               uintptr
+}
+
+// GetProcessMemoryInfo retrieves memory info for the given process handle.
+// https://docs.microsoft.com/en-us/windows/desktop/api/psapi/nf-psapi-getprocessmemoryinfo
+func GetProcessMemoryInfo(process syscall.Handle) (ProcessMemoryCountersEx, error) {
+	var info ProcessMemoryCountersEx
+	if err := _GetProcessMemoryInfo(process, &info, sizeofProcessMemoryCountersEx); err != nil {
+		return ProcessMemoryCountersEx{}, errors.Wrap(err, "GetProcessMemoryInfo failed")
+	}
+	return info, nil
+}

--- a/vendor/github.com/elastic/go-windows/utf16.go
+++ b/vendor/github.com/elastic/go-windows/utf16.go
@@ -1,16 +1,19 @@
-// Copyright 2018 Elasticsearch Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
 // http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 package windows
 

--- a/vendor/github.com/elastic/go-windows/version.go
+++ b/vendor/github.com/elastic/go-windows/version.go
@@ -1,16 +1,19 @@
-// Copyright 2018 Elasticsearch Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
 // http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 // +build windows
 

--- a/vendor/github.com/elastic/go-windows/zsyscall_windows.go
+++ b/vendor/github.com/elastic/go-windows/zsyscall_windows.go
@@ -37,6 +37,7 @@ func errnoErr(e syscall.Errno) error {
 var (
 	modkernel32 = syscall.NewLazyDLL("kernel32.dll")
 	modversion  = syscall.NewLazyDLL("version.dll")
+	modpsapi    = syscall.NewLazyDLL("psapi.dll")
 
 	procGetNativeSystemInfo     = modkernel32.NewProc("GetNativeSystemInfo")
 	procGetTickCount64          = modkernel32.NewProc("GetTickCount64")
@@ -45,6 +46,7 @@ var (
 	procGetFileVersionInfoW     = modversion.NewProc("GetFileVersionInfoW")
 	procGetFileVersionInfoSizeW = modversion.NewProc("GetFileVersionInfoSizeW")
 	procVerQueryValueW          = modversion.NewProc("VerQueryValueW")
+	procGetProcessMemoryInfo    = modpsapi.NewProc("GetProcessMemoryInfo")
 )
 
 func _GetNativeSystemInfo(systemInfo *SystemInfo) (err error) {
@@ -153,6 +155,18 @@ func __VerQueryValueW(data *byte, subBlock *uint16, pBuffer *uintptr, len *uint3
 	r0, _, e1 := syscall.Syscall6(procVerQueryValueW.Addr(), 4, uintptr(unsafe.Pointer(data)), uintptr(unsafe.Pointer(subBlock)), uintptr(unsafe.Pointer(pBuffer)), uintptr(unsafe.Pointer(len)), 0, 0)
 	success = r0 != 0
 	if !success {
+		if e1 != 0 {
+			err = errnoErr(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func _GetProcessMemoryInfo(handle syscall.Handle, psmemCounters *ProcessMemoryCountersEx, cb uint32) (err error) {
+	r1, _, e1 := syscall.Syscall(procGetProcessMemoryInfo.Addr(), 3, uintptr(handle), uintptr(unsafe.Pointer(psmemCounters)), uintptr(cb))
+	if r1 == 0 {
 		if e1 != 0 {
 			err = errnoErr(e1)
 		} else {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -9,10 +9,10 @@
 			"revisionTime": "2017-10-02T20:02:53Z"
 		},
 		{
-			"checksumSHA1": "rMbbrd8+vHPHFRDIv1OHuReNWCU=",
+			"checksumSHA1": "1ZPRU5w++g6fCsdzAmdrTVvpMqc=",
 			"path": "github.com/elastic/go-windows",
-			"revision": "50a4a6492c4dcd3344768da3cbee516bbd4580b4",
-			"revisionTime": "2018-03-27T02:49:44Z"
+			"revision": "5d078fa9943c7549875ad32ed0f5cc0efa9546e1",
+			"revisionTime": "2018-07-12T11:17:26Z"
 		},
 		{
 			"checksumSHA1": "l9wW52CYGbmO/NGwYZ/Op2QTmaA=",


### PR DESCRIPTION
Implement a minimal process provider for Windows; just enough to support sysinfo.Self().

All Processes now implement CPUTimer, so CPUTimer is embedded in the Process interface. Similarly,
all Processes now implement Memory, so the Memory method is transferred to Process, and the Memory interface removed.