### PR TITLE
ProcessProvider implementation for Windows

### DIFF
--- a/providers/windows/device_windows.go
+++ b/providers/windows/device_windows.go
@@ -1,0 +1,189 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package windows
+
+import (
+	"strings"
+	"unsafe"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sys/windows"
+)
+
+const (
+	DeviceMup        = "\\device\\mup"
+	LANManRedirector = "lanmanredirector"
+)
+
+var (
+	// ErrNoDevice is the error returned by DevicePathToDrivePath when
+	// an invalid device-path is supplied.
+	ErrNoDevice = errors.New("not a device path")
+
+	// ErrDeviceNotFound is the error returned by DevicePathToDrivePath when
+	// a path pointing to an unmapped device is passed.
+	ErrDeviceNotFound = errors.New("logical device not found")
+)
+
+type deviceProvider interface {
+	GetLogicalDrives() (uint32, error)
+	QueryDosDevice(*uint16, *uint16, uint32) (uint32, error)
+}
+
+type deviceMapper struct {
+	deviceProvider
+}
+
+type winapiDeviceProvider struct{}
+
+type testingDeviceProvider map[byte]string
+
+func newDeviceMapper() deviceMapper {
+	return deviceMapper{
+		deviceProvider: winapiDeviceProvider{},
+	}
+}
+
+func fixNetworkDrivePath(device string) string {
+	// For a VirtualBox share:
+	// device=\device\vboxminirdr\;z:\vboxsvr\share
+	// path=\device\vboxminirdr\vboxsvr\share
+	//
+	// For a network share:
+	// device=\device\lanmanredirector\;q:nnnnnnn\server\share
+	// path=\device\mup\server\share
+
+	semicolonPos := strings.IndexByte(device, ';')
+	colonPos := strings.IndexByte(device, ':')
+	if semicolonPos == -1 || colonPos != semicolonPos+2 {
+		return device
+	}
+	pathStart := strings.IndexByte(device[colonPos+1:], '\\')
+	if pathStart == -1 {
+		return device
+	}
+	dev := device[:semicolonPos]
+	path := device[colonPos+pathStart+1:]
+	n := len(dev)
+	if n > 0 && dev[n-1] == '\\' {
+		dev = dev[:n-1]
+	}
+	return dev + path
+}
+
+func (mapper *deviceMapper) getDevice(driveLetter byte) (string, error) {
+	driveBuf := [3]uint16{uint16(driveLetter), ':', 0}
+
+	for bufSize := 64; bufSize <= 1024; bufSize *= 2 {
+		deviceBuf := make([]uint16, bufSize)
+		n, err := mapper.QueryDosDevice(&driveBuf[0], &deviceBuf[0], uint32(len(deviceBuf)))
+		if err != nil {
+			if err == windows.ERROR_INSUFFICIENT_BUFFER {
+				continue
+			}
+			return "", err
+		}
+		return windows.UTF16ToString(deviceBuf[:n]), nil
+	}
+	return "", windows.ERROR_INSUFFICIENT_BUFFER
+}
+
+func (mapper *deviceMapper) DevicePathToDrivePath(path string) (string, error) {
+	pathLower := strings.ToLower(path)
+	isMUP := strings.Index(pathLower, DeviceMup) == 0
+	mask, err := mapper.GetLogicalDrives()
+	if err != nil {
+		return "", errors.Wrap(err, "GetLogicalDrives")
+	}
+
+	for bit := uint32(0); mask != 0 && bit < uint32('Z'-'A'+1); bit++ {
+		if mask&(1<<bit) == 0 {
+			continue
+		}
+		mask ^= 1 << bit
+		driveLetter := byte('A' + bit)
+		dev, err := mapper.getDevice(driveLetter)
+		if err != nil {
+			continue
+		}
+
+		dev = fixNetworkDrivePath(strings.ToLower(dev))
+		found := strings.Index(pathLower, dev) == 0
+
+		if !found && isMUP && strings.Contains(dev, LANManRedirector) {
+			dev = strings.Replace(dev, LANManRedirector, "mup", 1)
+			found = strings.Index(pathLower, dev) == 0
+		}
+		if found {
+			off := len(dev)
+			if off < len(path) && path[off] == '\\' {
+				off += 1
+			}
+			return string(driveLetter) + ":\\" + path[off:], nil
+		}
+	}
+	// Handle unmapped shares:
+	// \device\mup\server\share\path -> \\server\share\path
+	if isMUP {
+		return "\\" + path[len(DeviceMup):], nil
+	}
+	return "", ErrDeviceNotFound
+}
+
+func (_ winapiDeviceProvider) GetLogicalDrives() (uint32, error) {
+	return windows.GetLogicalDrives()
+}
+
+func (_ winapiDeviceProvider) QueryDosDevice(name *uint16, buf *uint16, length uint32) (uint32, error) {
+	return windows.QueryDosDevice(name, buf, length)
+}
+
+func (m testingDeviceProvider) GetLogicalDrives() (mask uint32, err error) {
+	for drive := range m {
+		mask |= 1 << uint32(drive-'A')
+	}
+	return mask, nil
+}
+
+func ptrOffset(ptr *uint16, off uint32) *uint16 {
+	return (*uint16)(unsafe.Pointer(uintptr(unsafe.Pointer(ptr)) + uintptr(off*2)))
+}
+
+func (m testingDeviceProvider) QueryDosDevice(nameW *uint16, buf *uint16, length uint32) (uint32, error) {
+	drive := byte(*nameW)
+	if byte(*ptrOffset(nameW, 1)) != ':' {
+		return 0, errors.New("not a drive")
+	}
+	if *ptrOffset(nameW, 2) != 0 {
+		return 0, errors.New("drive not terminated")
+	}
+	path, ok := m[drive]
+	if !ok {
+		return 0, errors.Errorf("drive %c not found", drive)
+	}
+	n := uint32(len(path))
+	if n+2 > length {
+		return 0, windows.ERROR_INSUFFICIENT_BUFFER
+	}
+	for i := uint32(0); i < n; i++ {
+		*ptrOffset(buf, i) = uint16(path[i])
+	}
+	*ptrOffset(buf, n) = 0
+	*ptrOffset(buf, n+1) = 0
+	return n + 2, nil
+}

--- a/providers/windows/device_windows_test.go
+++ b/providers/windows/device_windows_test.go
@@ -1,0 +1,68 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package windows
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeviceMapper(t *testing.T) {
+	devMapper := deviceMapper{
+		deviceProvider: testingDeviceProvider(map[byte]string{
+			'A': `\Device\Floppy0`,
+			'B': `\Device\Floppy1`,
+			'C': `\Device\Harddisk0Volume2`,
+			'D': `\Device\Harddisk1Volume1`,
+			'E': `\Device\Cdrom0`,
+			// Virtualbox-style share
+			'W': `\Device\Share;w:\dataserver\programs`,
+			// Network share
+			'Z': `\Device\LANManRedirector;z:01234567812313123\officeserver\documents`,
+		}),
+	}
+	for testIdx, testCase := range []struct {
+		devicePath, expected string
+	}{
+		{`\DEVICE\FLOPPY0\README.TXT`, `A:\README.TXT`},
+		{`\Device\cdrom0\autorun.INF`, `E:\autorun.INF`},
+		{`\Device\Harddisk0Volume2\WINDOWS\System32\drivers\etc\hosts`, `C:\WINDOWS\System32\drivers\etc\hosts`},
+		{`\Device\share\DATASERVER\PROGRAMS\elastic\packetbeat\PACKETBEAT.EXE`, `W:\elastic\packetbeat\PACKETBEAT.EXE`},
+		{`\Device\MUP\OfficeServer\Documents\report.pdf`, `Z:\report.pdf`},
+		{`\Device\share\othershare\files\run.EXE`, ``},
+		{`\Device\MUP\networkserver\share\.git`, `\\networkserver\share\.git`},
+		{`\Device\Harddisk1Volume1`, `D:\`},
+		{`\Device\Harddisk1Volume1\`, `D:\`},
+		{`\Device`, ``},
+		{`C:\windows\calc.exe`, ``},
+	} {
+		msg := fmt.Sprintf("test case #%d: %v", testIdx, testCase)
+		path, err := devMapper.DevicePathToDrivePath(testCase.devicePath)
+		if err == nil {
+			assert.Equal(t, testCase.expected, path, msg)
+		} else {
+			if len(testCase.expected) != 0 {
+				t.Fatal(err, msg)
+				continue
+			}
+			assert.Equal(t, testCase.expected, path, msg)
+		}
+	}
+}

--- a/providers/windows/process_windows.go
+++ b/providers/windows/process_windows.go
@@ -20,28 +20,42 @@ package windows
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
+	"unsafe"
+
+	"github.com/pkg/errors"
 
 	"github.com/elastic/go-windows"
-
 	"github.com/elastic/go-sysinfo/types"
 )
 
 var (
-	selfPID = os.Getpid()
+	selfPID   = os.Getpid()
+	devMapper = newDeviceMapper()
 )
 
-func (s windowsSystem) Processes() ([]types.Process, error) {
-	return nil, types.ErrNotImplemented
+func (s windowsSystem) Processes() (procs []types.Process, err error) {
+	pids, err := windows.EnumProcesses()
+	if err != nil {
+		return nil, errors.Wrap(err, "EnumProcesses")
+	}
+	procs = make([]types.Process, 0, len(pids))
+	var proc types.Process
+	for _, pid := range pids {
+		if proc, err = s.Process(int(pid)); err == nil {
+			procs = append(procs, proc)
+		}
+	}
+	if len(procs) == 0 {
+		return nil, err
+	}
+	return procs, nil
 }
 
 func (s windowsSystem) Process(pid int) (types.Process, error) {
-	if pid == selfPID {
-		return s.Self()
-	}
-	// TODO implement support for enumerating processes.
-	return nil, types.ErrNotImplemented
+	return newProcess(pid)
 }
 
 func (s windowsSystem) Self() (types.Process, error) {
@@ -62,50 +76,164 @@ func newProcess(pid int) (*process, error) {
 }
 
 func (p *process) init() error {
-	if p.pid != selfPID {
-		// TODO implement support for other processes.
-		return types.ErrNotImplemented
-	}
-
-	exe, err := os.Executable()
-	if err != nil {
-		return err
-	}
-
-	cwd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-
 	handle, err := p.open()
 	if err != nil {
 		return err
 	}
 	defer syscall.CloseHandle(handle)
 
+	var path string
+	if imgf, err := windows.GetProcessImageFileName(handle); err == nil {
+		path, err = devMapper.DevicePathToDrivePath(imgf)
+		if err != nil {
+			path = imgf
+		}
+	}
+
 	var creationTime, exitTime, kernelTime, userTime syscall.Filetime
 	if err := syscall.GetProcessTimes(handle, &creationTime, &exitTime, &kernelTime, &userTime); err != nil {
 		return err
 	}
 
+	// Try to read the RTL_USER_PROCESS_PARAMETERS struct from the target process
+	// memory. This can fail due to missing access rights or when we are running
+	// as a 32bit process in a 64bit system (WOW64).
+	// Don't make this a fatal error: If it fails, `args` and `cwd` fields will
+	// be missing.
+	var args []string
+	var cwd string
+	var ppid int
+	pbi, err := getProcessBasicInformation(handle)
+	if err == nil {
+		ppid = int(pbi.InheritedFromUniqueProcessID)
+		userProcParams, err := getUserProcessParams(handle, pbi)
+		if err == nil {
+			if argsW, err := readProcessUnicodeString(handle, &userProcParams.CommandLine); err == nil {
+				args, err = splitCommandline(argsW)
+				if err != nil {
+					args = nil
+				}
+			}
+			if cwdW, err := readProcessUnicodeString(handle, &userProcParams.CurrentDirectoryPath); err == nil {
+				cwd, _, err = windows.UTF16BytesToString(cwdW)
+				if err != nil {
+					cwd = ""
+				}
+				// Remove trailing separator
+				cwd = strings.TrimRight(cwd, "\\")
+			}
+		}
+	}
+
 	p.info = types.ProcessInfo{
-		Name:      filepath.Base(exe),
-		PID:       selfPID,
-		PPID:      os.Getppid(),
+		Name:      filepath.Base(path),
+		PID:       p.pid,
+		PPID:      ppid,
+		Exe:       path,
+		Args:      args,
 		CWD:       cwd,
-		Exe:       exe,
-		Args:      os.Args[:],
 		StartTime: time.Unix(0, creationTime.Nanoseconds()),
 	}
 	return nil
 }
 
-func (p *process) open() (syscall.Handle, error) {
-	if p.pid != selfPID {
-		// TODO implement support for other processes.
-		return 0, types.ErrNotImplemented
+func getProcessBasicInformation(handle syscall.Handle) (pbi windows.ProcessBasicInformationStruct, err error) {
+	actualSize, err := windows.NtQueryInformationProcess(handle, windows.ProcessBasicInformation, unsafe.Pointer(&pbi), uint32(windows.SizeOfProcessBasicInformationStruct))
+	if actualSize < uint32(windows.SizeOfProcessBasicInformationStruct) {
+		return pbi, errors.New("bad size for PROCESS_BASIC_INFORMATION")
 	}
-	return syscall.GetCurrentProcess()
+	return pbi, err
+}
+
+func getUserProcessParams(handle syscall.Handle, pbi windows.ProcessBasicInformationStruct) (params windows.RtlUserProcessParameters, err error) {
+	const is32bitProc = unsafe.Sizeof(uintptr(0)) == 4
+
+	// Offset of params field within PEB structure.
+	// This structure is different in 32 and 64 bit.
+	paramsOffset := 0x20
+	if is32bitProc {
+		paramsOffset = 0x10
+	}
+
+	// Read the PEB from the target process memory
+	pebSize := paramsOffset + 8
+	peb := make([]byte, pebSize)
+	nRead, err := windows.ReadProcessMemory(handle, pbi.PebBaseAddress, peb)
+	if err != nil {
+		return params, err
+	}
+	if nRead != uintptr(pebSize) {
+		return params, errors.Errorf("PEB: short read (%d/%d)", nRead, pebSize)
+	}
+
+	// Get the RTL_USER_PROCESS_PARAMETERS struct pointer from the PEB
+	paramsAddr := *(*uintptr)(unsafe.Pointer(&peb[paramsOffset]))
+
+	// Read the RTL_USER_PROCESS_PARAMETERS from the target process memory
+	paramsBuf := make([]byte, windows.SizeOfRtlUserProcessParameters)
+	nRead, err = windows.ReadProcessMemory(handle, paramsAddr, paramsBuf)
+	if err != nil {
+		return params, err
+	}
+	if nRead != uintptr(windows.SizeOfRtlUserProcessParameters) {
+		return params, errors.Errorf("RTL_USER_PROCESS_PARAMETERS: short read (%d/%d)", nRead, windows.SizeOfRtlUserProcessParameters)
+	}
+
+	params = *(*windows.RtlUserProcessParameters)(unsafe.Pointer(&paramsBuf[0]))
+	return params, nil
+}
+
+// read an UTF-16 string from another process memory. Result is an []byte
+// with the UTF-16 data.
+func readProcessUnicodeString(handle syscall.Handle, s *windows.UnicodeString) ([]byte, error) {
+	buf := make([]byte, s.Size)
+	nRead, err := windows.ReadProcessMemory(handle, s.Buffer, buf)
+	if err != nil {
+		return nil, err
+	}
+	if nRead != uintptr(s.Size) {
+		return nil, errors.Errorf("unicode string: short read: (%d/%d)", nRead, s.Size)
+	}
+	return buf, nil
+}
+
+// Use Windows' CommandLineToArgv API to split an UTF-16 command line string
+// into a list of parameters.
+func splitCommandline(utf16 []byte) ([]string, error) {
+	if len(utf16) == 0 {
+		return nil, nil
+	}
+	var numArgs int32
+	argsWide, err := syscall.CommandLineToArgv((*uint16)(unsafe.Pointer(&utf16[0])), &numArgs)
+	if err != nil {
+		return nil, err
+	}
+	args := make([]string, numArgs)
+	for idx := range args {
+		args[idx] = syscall.UTF16ToString(argsWide[idx][:])
+	}
+	return args, nil
+}
+
+func (p *process) open() (handle syscall.Handle, err error) {
+	if p.pid == selfPID {
+		return syscall.GetCurrentProcess()
+	}
+
+	// Try different access rights, from broader to more limited.
+	// PROCESS_VM_READ is needed to get command-line and working directory
+	// PROCESS_QUERY_LIMITED_INFORMATION is only available in Vista+
+	for _, permissions := range [4]uint32{
+		syscall.PROCESS_QUERY_INFORMATION 		  | windows.PROCESS_VM_READ,
+		windows.PROCESS_QUERY_LIMITED_INFORMATION | windows.PROCESS_VM_READ,
+		syscall.PROCESS_QUERY_INFORMATION,
+		windows.PROCESS_QUERY_LIMITED_INFORMATION,
+	} {
+		if handle, err = syscall.OpenProcess(permissions, false, uint32(p.pid)); err == nil {
+			break
+		}
+	}
+	return handle, err
 }
 
 func (p *process) Info() (types.ProcessInfo, error) {

--- a/system_test.go
+++ b/system_test.go
@@ -230,3 +230,25 @@ func logAsJSON(t testing.TB, v interface{}) {
 	j, _ := json.MarshalIndent(v, "", "  ")
 	t.Log(string(j))
 }
+
+func TestProcesses(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("run only on windows")
+	}
+	start := time.Now()
+	procs, err := Processes()
+	took := time.Now().Sub(start)
+	t.Log("took", took)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log("found", len(procs), "processes")
+	for _, proc := range procs {
+		info, err := proc.Info()
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("pid=%v name='%s' exe='%s' args=%+v ppid=%d cwd='%s' start_time=%v", info.PID, info.Name, info.Exe, info.Args, info.PPID, info.CWD, info.StartTime)
+	}
+
+}

--- a/vendor/github.com/elastic/go-windows/constants.go
+++ b/vendor/github.com/elastic/go-windows/constants.go
@@ -15,9 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Package windows contains various Windows system calls.
+// +build windows
+
 package windows
 
-// Use "GOOS=windows go generate -v -x" to generate the sources.
-// Add -trace to enable debug prints around syscalls.
-//go:generate go run $GOROOT/src/syscall/mksyscall_windows.go -systemdll=false -output zsyscall_windows.go kernel32.go version.go psapi.go ntdll.go
+const (
+	// This process access rights are missing from Go's syscall package as of 1.10.3
+	PROCESS_VM_READ                   = 0x10
+	PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+)

--- a/vendor/github.com/elastic/go-windows/kernel32.go
+++ b/vendor/github.com/elastic/go-windows/kernel32.go
@@ -33,6 +33,7 @@ import (
 //sys   _GetTickCount64() (millis uint64, err error) = kernel32.GetTickCount64
 //sys   _GetSystemTimes(idleTime *syscall.Filetime, kernelTime *syscall.Filetime, userTime *syscall.Filetime) (err error) = kernel32.GetSystemTimes
 //sys   _GlobalMemoryStatusEx(buffer *MemoryStatusEx) (err error) = kernel32.GlobalMemoryStatusEx
+//sys   _ReadProcessMemory(handle syscall.Handle, baseAddress uintptr, buffer uintptr, size uintptr, numRead *uintptr) (err error) = kernel32.ReadProcessMemory
 
 var (
 	sizeofMemoryStatusEx = uint32(unsafe.Sizeof(MemoryStatusEx{}))
@@ -217,4 +218,18 @@ func GlobalMemoryStatusEx() (MemoryStatusEx, error) {
 	}
 
 	return memoryStatusEx, nil
+}
+
+// ReadProcessMemory reads from another process memory. The Handle needs to have
+// the PROCESS_VM_READ right.
+// A zero-byte read is a no-op, no error is returned.
+func ReadProcessMemory(handle syscall.Handle, baseAddress uintptr, dest []byte) (numRead uintptr, err error) {
+	n := len(dest)
+	if n == 0 {
+		return 0, nil
+	}
+	if err = _ReadProcessMemory(handle, baseAddress, uintptr(unsafe.Pointer(&dest[0])), uintptr(n), &numRead); err != nil {
+		return 0, err
+	}
+	return numRead, nil
 }

--- a/vendor/github.com/elastic/go-windows/ntdll.go
+++ b/vendor/github.com/elastic/go-windows/ntdll.go
@@ -1,0 +1,157 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build windows
+
+package windows
+
+import (
+	"fmt"
+	"syscall"
+	"unsafe"
+)
+
+const (
+	SizeOfProcessBasicInformationStruct = unsafe.Sizeof(ProcessBasicInformationStruct{})
+	SizeOfRtlUserProcessParameters      = unsafe.Sizeof(RtlUserProcessParameters{})
+)
+
+// NTStatus is an error wrapper for NTSTATUS values, 32bit error-codes returned
+// by the NT Kernel.
+type NTStatus uint32
+
+// ProcessInformationClass is Go's counterpart for the PROCESSINFOCLASS enumeration
+// defined in ntdll.h.
+type ProcessInfoClass uint32
+
+const (
+	ProcessBasicInformation ProcessInfoClass = iota
+	ProcessQuotaLimits
+	ProcessIoCounters
+	ProcessVmCounters
+	ProcessTimes
+	ProcessBasePriority
+	ProcessRaisePriority
+	ProcessDebugPort
+	ProcessExceptionPort
+	ProcessAccessToken
+	ProcessLdtInformation
+	ProcessLdtSize
+	ProcessDefaultHardErrorMode
+	ProcessIoPortHandlers
+	ProcessPooledUsageAndLimits
+	ProcessWorkingSetWatch
+	ProcessUserModeIOPL
+	ProcessEnableAlignmentFaultFixup
+	ProcessPriorityClass
+	ProcessWx86Information
+	ProcessHandleCount
+	ProcessAffinityMask
+	ProcessPriorityBoost
+	ProcessDeviceMap
+	ProcessSessionInformation
+	ProcessForegroundInformation
+	ProcessWow64Information
+	ProcessImageFileName
+	ProcessLUIDDeviceMapsEnabled
+	ProcessBreakOnTermination
+	ProcessDebugObjectHandle
+	ProcessDebugFlags
+	ProcessHandleTracing
+	ProcessIoPriority
+	ProcessExecuteFlags
+	ProcessResourceManagement
+	ProcessCookie
+	ProcessImageInformation
+	ProcessCycleTime
+	ProcessPagePriority
+	ProcessInstrumentationCallback
+	ProcessThreadStackAllocation
+	ProcessWorkingSetWatchEx
+	ProcessImageFileNameWin32
+	ProcessImageFileMapping
+	ProcessAffinityUpdateMode
+	ProcessMemoryAllocationMode
+	ProcessGroupInformation
+	ProcessTokenVirtualizationEnabled
+	ProcessConsoleHostProcess
+	ProcessWindowInformation
+	ProcessHandleInformation
+	ProcessMitigationPolicy
+	ProcessDynamicFunctionTableInformation
+	ProcessHandleCheckingMode
+	ProcessKeepAliveCount
+	ProcessRevokeFileHandles
+	MaxProcessInfoClass
+)
+
+// ProcessBasicInformationStruct is Go's counterpart of the
+// PROCESS_BASIC_INFORMATION struct, returned by NtQueryInformationProcess
+// when ProcessBasicInformation is requested.
+type ProcessBasicInformationStruct struct {
+	Reserved1       			 uintptr
+	PebBaseAddress  			 uintptr
+	Reserved2       			 [2]uintptr
+	UniqueProcessId 			 uintptr
+	// Undocumented:
+	InheritedFromUniqueProcessID uintptr
+}
+
+// UnicodeString is Go's equivalent for the _UNICODE_STRING struct.
+type UnicodeString struct {
+	Size          uint16
+	MaximumLength uint16
+	Buffer        uintptr
+}
+
+// RtlUserProcessParameters is Go's equivalent for the
+// _RTL_USER_PROCESS_PARAMETERS struct.
+// A few undocumented fields are exposed.
+type RtlUserProcessParameters struct {
+	Reserved1 [16]byte
+	Reserved2 [5]uintptr
+
+	// <undocumented>
+	CurrentDirectoryPath   UnicodeString
+	CurrentDirectoryHandle uintptr
+	DllPath                UnicodeString
+	// </undocumented>
+
+	ImagePathName UnicodeString
+	CommandLine   UnicodeString
+}
+
+// Syscalls
+// Warning: NtQueryInformationProcess is an unsupported API that can change
+//          in future versions of Windows. Available from XP to Windows 10.
+//sys   _NtQueryInformationProcess(handle syscall.Handle, infoClass uint32, info uintptr, infoLen uint32, returnLen *uint32) (ntStatus uint32) = ntdll.NtQueryInformationProcess
+
+// NtQueryInformationProcess is a wrapper for ntdll.NtQueryInformationProcess.
+// The handle must have the PROCESS_QUERY_INFORMATION access right.
+// Returns an error of type NTStatus.
+func NtQueryInformationProcess(handle syscall.Handle, infoClass ProcessInfoClass, info unsafe.Pointer, infoLen uint32) (returnedLen uint32, err error) {
+	status := _NtQueryInformationProcess(handle, uint32(infoClass), uintptr(info), infoLen, &returnedLen)
+	if status != 0 {
+		return returnedLen, NTStatus(status)
+	}
+	return returnedLen, nil
+}
+
+// Error prints the wrapped NTSTATUS in hex form.
+func (status NTStatus) Error() string {
+	return fmt.Sprintf("ntstatus=%x", uint32(status))
+}

--- a/vendor/github.com/elastic/go-windows/psapi.go
+++ b/vendor/github.com/elastic/go-windows/psapi.go
@@ -28,6 +28,8 @@ import (
 
 // Syscalls
 //sys   _GetProcessMemoryInfo(handle syscall.Handle, psmemCounters *ProcessMemoryCountersEx, cb uint32) (err error) = psapi.GetProcessMemoryInfo
+//sys   _GetProcessImageFileNameA(handle syscall.Handle, imageFileName *byte, nSize uint32) (len uint32, err error) = psapi.GetProcessImageFileNameA
+//sys   _EnumProcesses(lpidProcess *uint32, cb uint32, lpcbNeeded *uint32) (err error) = psapi.EnumProcesses
 
 var (
 	sizeofProcessMemoryCountersEx = uint32(unsafe.Sizeof(ProcessMemoryCountersEx{}))
@@ -59,4 +61,39 @@ func GetProcessMemoryInfo(process syscall.Handle) (ProcessMemoryCountersEx, erro
 		return ProcessMemoryCountersEx{}, errors.Wrap(err, "GetProcessMemoryInfo failed")
 	}
 	return info, nil
+}
+
+// GetProcessImageFileName retrieves the process main executable.
+// The returned path is a device path, that is:
+// "\Device\HardDisk0Volume1\Windows\notepad.exe"
+// instead of
+// "C:\Windows\notepad.exe"
+// Use QueryDosDevice or equivalent to convert to a drive path.
+func GetProcessImageFileName(handle syscall.Handle) (string, error) {
+	for bufLen, limit := syscall.MAX_PATH, syscall.MAX_PATH*4; bufLen <= limit; bufLen *= 2 {
+		buf := make([]byte, bufLen)
+		nameLen, err := _GetProcessImageFileNameA(handle, &buf[0], uint32(len(buf)))
+		if err == nil {
+			buf = buf[:nameLen]
+			return string(buf), nil
+		}
+		if err != syscall.ERROR_INSUFFICIENT_BUFFER {
+			return "", err
+		}
+	}
+	return "", syscall.ERROR_INSUFFICIENT_BUFFER
+}
+
+// EnumProcesses
+// TODO
+func EnumProcesses() (pids []uint32, err error) {
+	for nAlloc, nGot := uint32(128), uint32(0) ; ; nAlloc *= 2 {
+		pids = make([]uint32, nAlloc)
+		if err = _EnumProcesses(&pids[0], nAlloc * 4, &nGot); err != nil {
+			return nil, err
+		}
+		if nGot / 4 < nAlloc {
+			return pids, nil
+		}
+	}
 }

--- a/vendor/github.com/elastic/go-windows/zsyscall_windows.go
+++ b/vendor/github.com/elastic/go-windows/zsyscall_windows.go
@@ -38,15 +38,20 @@ var (
 	modkernel32 = syscall.NewLazyDLL("kernel32.dll")
 	modversion  = syscall.NewLazyDLL("version.dll")
 	modpsapi    = syscall.NewLazyDLL("psapi.dll")
+	modntdll    = syscall.NewLazyDLL("ntdll.dll")
 
-	procGetNativeSystemInfo     = modkernel32.NewProc("GetNativeSystemInfo")
-	procGetTickCount64          = modkernel32.NewProc("GetTickCount64")
-	procGetSystemTimes          = modkernel32.NewProc("GetSystemTimes")
-	procGlobalMemoryStatusEx    = modkernel32.NewProc("GlobalMemoryStatusEx")
-	procGetFileVersionInfoW     = modversion.NewProc("GetFileVersionInfoW")
-	procGetFileVersionInfoSizeW = modversion.NewProc("GetFileVersionInfoSizeW")
-	procVerQueryValueW          = modversion.NewProc("VerQueryValueW")
-	procGetProcessMemoryInfo    = modpsapi.NewProc("GetProcessMemoryInfo")
+	procGetNativeSystemInfo       = modkernel32.NewProc("GetNativeSystemInfo")
+	procGetTickCount64            = modkernel32.NewProc("GetTickCount64")
+	procGetSystemTimes            = modkernel32.NewProc("GetSystemTimes")
+	procGlobalMemoryStatusEx      = modkernel32.NewProc("GlobalMemoryStatusEx")
+	procReadProcessMemory         = modkernel32.NewProc("ReadProcessMemory")
+	procGetFileVersionInfoW       = modversion.NewProc("GetFileVersionInfoW")
+	procGetFileVersionInfoSizeW   = modversion.NewProc("GetFileVersionInfoSizeW")
+	procVerQueryValueW            = modversion.NewProc("VerQueryValueW")
+	procGetProcessMemoryInfo      = modpsapi.NewProc("GetProcessMemoryInfo")
+	procGetProcessImageFileNameA  = modpsapi.NewProc("GetProcessImageFileNameA")
+	procEnumProcesses             = modpsapi.NewProc("EnumProcesses")
+	procNtQueryInformationProcess = modntdll.NewProc("NtQueryInformationProcess")
 )
 
 func _GetNativeSystemInfo(systemInfo *SystemInfo) {
@@ -81,6 +86,18 @@ func _GetSystemTimes(idleTime *syscall.Filetime, kernelTime *syscall.Filetime, u
 
 func _GlobalMemoryStatusEx(buffer *MemoryStatusEx) (err error) {
 	r1, _, e1 := syscall.Syscall(procGlobalMemoryStatusEx.Addr(), 1, uintptr(unsafe.Pointer(buffer)), 0, 0)
+	if r1 == 0 {
+		if e1 != 0 {
+			err = errnoErr(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func _ReadProcessMemory(handle syscall.Handle, baseAddress uintptr, buffer uintptr, size uintptr, numRead *uintptr) (err error) {
+	r1, _, e1 := syscall.Syscall6(procReadProcessMemory.Addr(), 5, uintptr(handle), uintptr(baseAddress), uintptr(buffer), uintptr(size), uintptr(unsafe.Pointer(numRead)), 0)
 	if r1 == 0 {
 		if e1 != 0 {
 			err = errnoErr(e1)
@@ -166,5 +183,36 @@ func _GetProcessMemoryInfo(handle syscall.Handle, psmemCounters *ProcessMemoryCo
 			err = syscall.EINVAL
 		}
 	}
+	return
+}
+
+func _GetProcessImageFileNameA(handle syscall.Handle, imageFileName *byte, nSize uint32) (len uint32, err error) {
+	r0, _, e1 := syscall.Syscall(procGetProcessImageFileNameA.Addr(), 3, uintptr(handle), uintptr(unsafe.Pointer(imageFileName)), uintptr(nSize))
+	len = uint32(r0)
+	if len == 0 {
+		if e1 != 0 {
+			err = errnoErr(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func _EnumProcesses(lpidProcess *uint32, cb uint32, lpcbNeeded *uint32) (err error) {
+	r1, _, e1 := syscall.Syscall(procEnumProcesses.Addr(), 3, uintptr(unsafe.Pointer(lpidProcess)), uintptr(cb), uintptr(unsafe.Pointer(lpcbNeeded)))
+	if r1 == 0 {
+		if e1 != 0 {
+			err = errnoErr(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func _NtQueryInformationProcess(handle syscall.Handle, infoClass uint32, info uintptr, infoLen uint32, returnLen *uint32) (ntStatus uint32) {
+	r0, _, _ := syscall.Syscall6(procNtQueryInformationProcess.Addr(), 5, uintptr(handle), uintptr(infoClass), uintptr(info), uintptr(infoLen), uintptr(unsafe.Pointer(returnLen)), 0)
+	ntStatus = uint32(r0)
 	return
 }


### PR DESCRIPTION
This adds support for obtaining information about arbitrary processes under Windows OS. Previously, it was possible to fetch information about the current process only.

This relies on some undocumented APIs and structures to fetch command-line arguments and current working directory.

It is meant to work in XP onwards. As a 32 bit process under a 32 bit OS or a 64 bit process in a 64 bit OS. Some features will be missing when running as a 32-bit process in a 64-bit OS (WOW64): Command-line arguments and cwd.

