### PR TITLE
Fix registry handle leak on Windows

### DIFF
--- a/providers/windows/machineid_windows.go
+++ b/providers/windows/machineid_windows.go
@@ -35,6 +35,7 @@ func getMachineGUID() (string, error) {
 	if err != nil {
 		return "", errors.Wrapf(err, `failed to open HKLM\%v`, path)
 	}
+	defer k.Close()
 
 	guid, _, err := k.GetStringValue(name)
 	if err != nil {

--- a/providers/windows/os_windows.go
+++ b/providers/windows/os_windows.go
@@ -37,6 +37,7 @@ func OperatingSystem() (*types.OSInfo, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, `failed to open HKLM\%v`, path)
 	}
+	defer k.Close()
 
 	osInfo := &types.OSInfo{
 		Family:   "windows",


### PR DESCRIPTION
Close the handles used to fetch the machine ID and OS version.

Fixes #30