### PR TITLE
Add user information to process

### DIFF
--- a/providers/darwin/process_darwin_amd64.go
+++ b/providers/darwin/process_darwin_amd64.go
@@ -28,6 +28,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"os"
+	"strconv"
 	"time"
 	"unsafe"
 
@@ -84,6 +85,12 @@ func (p *process) Info() (types.ProcessInfo, error) {
 		Args: p.args,
 		StartTime: time.Unix(int64(task.Pbsd.Pbi_start_tvsec),
 			int64(task.Pbsd.Pbi_start_tvusec)*int64(time.Microsecond)),
+		UID:   strconv.Itoa(int(task.Pbsd.Pbi_uid)),
+		RUID:  strconv.Itoa(int(task.Pbsd.Pbi_ruid)),
+		SVUID: strconv.Itoa(int(task.Pbsd.Pbi_svuid)),
+		GID:   strconv.Itoa(int(task.Pbsd.Pbi_gid)),
+		RGID:  strconv.Itoa(int(task.Pbsd.Pbi_rgid)),
+		SVGID: strconv.Itoa(int(task.Pbsd.Pbi_svgid)),
 	}, nil
 }
 

--- a/providers/darwin/process_darwin_amd64.go
+++ b/providers/darwin/process_darwin_amd64.go
@@ -85,12 +85,22 @@ func (p *process) Info() (types.ProcessInfo, error) {
 		Args: p.args,
 		StartTime: time.Unix(int64(task.Pbsd.Pbi_start_tvsec),
 			int64(task.Pbsd.Pbi_start_tvusec)*int64(time.Microsecond)),
-		UID:   strconv.Itoa(int(task.Pbsd.Pbi_uid)),
-		RUID:  strconv.Itoa(int(task.Pbsd.Pbi_ruid)),
-		SVUID: strconv.Itoa(int(task.Pbsd.Pbi_svuid)),
-		GID:   strconv.Itoa(int(task.Pbsd.Pbi_gid)),
-		RGID:  strconv.Itoa(int(task.Pbsd.Pbi_rgid)),
-		SVGID: strconv.Itoa(int(task.Pbsd.Pbi_svgid)),
+	}, nil
+}
+
+func (p *process) User() (types.UserInfo, error) {
+	var task procTaskAllInfo
+	if err := getProcTaskAllInfo(p.pid, &task); err != nil {
+		return types.UserInfo{}, err
+	}
+
+	return types.UserInfo{
+		UID:  strconv.Itoa(int(task.Pbsd.Pbi_ruid)),
+		EUID: strconv.Itoa(int(task.Pbsd.Pbi_uid)),
+		SUID: strconv.Itoa(int(task.Pbsd.Pbi_svuid)),
+		GID:  strconv.Itoa(int(task.Pbsd.Pbi_rgid)),
+		EGID: strconv.Itoa(int(task.Pbsd.Pbi_gid)),
+		SGID: strconv.Itoa(int(task.Pbsd.Pbi_svgid)),
 	}, nil
 }
 

--- a/providers/darwin/process_darwin_amd64.go
+++ b/providers/darwin/process_darwin_amd64.go
@@ -95,12 +95,12 @@ func (p *process) User() (types.UserInfo, error) {
 	}
 
 	return types.UserInfo{
-		Uid:  strconv.Itoa(int(task.Pbsd.Pbi_ruid)),
-		Euid: strconv.Itoa(int(task.Pbsd.Pbi_uid)),
-		Suid: strconv.Itoa(int(task.Pbsd.Pbi_svuid)),
-		Gid:  strconv.Itoa(int(task.Pbsd.Pbi_rgid)),
-		Egid: strconv.Itoa(int(task.Pbsd.Pbi_gid)),
-		Sgid: strconv.Itoa(int(task.Pbsd.Pbi_svgid)),
+		UID:  strconv.Itoa(int(task.Pbsd.Pbi_ruid)),
+		EUID: strconv.Itoa(int(task.Pbsd.Pbi_uid)),
+		SUID: strconv.Itoa(int(task.Pbsd.Pbi_svuid)),
+		GID:  strconv.Itoa(int(task.Pbsd.Pbi_rgid)),
+		EGID: strconv.Itoa(int(task.Pbsd.Pbi_gid)),
+		SGID: strconv.Itoa(int(task.Pbsd.Pbi_svgid)),
 	}, nil
 }
 

--- a/providers/darwin/process_darwin_amd64.go
+++ b/providers/darwin/process_darwin_amd64.go
@@ -95,12 +95,12 @@ func (p *process) User() (types.UserInfo, error) {
 	}
 
 	return types.UserInfo{
-		UID:  strconv.Itoa(int(task.Pbsd.Pbi_ruid)),
-		EUID: strconv.Itoa(int(task.Pbsd.Pbi_uid)),
-		SUID: strconv.Itoa(int(task.Pbsd.Pbi_svuid)),
-		GID:  strconv.Itoa(int(task.Pbsd.Pbi_rgid)),
-		EGID: strconv.Itoa(int(task.Pbsd.Pbi_gid)),
-		SGID: strconv.Itoa(int(task.Pbsd.Pbi_svgid)),
+		Uid:  strconv.Itoa(int(task.Pbsd.Pbi_ruid)),
+		Euid: strconv.Itoa(int(task.Pbsd.Pbi_uid)),
+		Suid: strconv.Itoa(int(task.Pbsd.Pbi_svuid)),
+		Gid:  strconv.Itoa(int(task.Pbsd.Pbi_rgid)),
+		Egid: strconv.Itoa(int(task.Pbsd.Pbi_gid)),
+		Sgid: strconv.Itoa(int(task.Pbsd.Pbi_svgid)),
 	}, nil
 }
 

--- a/providers/linux/process_linux.go
+++ b/providers/linux/process_linux.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/prometheus/procfs"
@@ -202,6 +203,33 @@ func (p *process) Capabilities() (*types.CapabilityInfo, error) {
 	}
 
 	return readCapabilities(content)
+}
+
+func (p *process) User() (types.UserInfo, error) {
+	content, err := ioutil.ReadFile(p.path("status"))
+	if err != nil {
+		return types.UserInfo{}, err
+	}
+
+	var user types.UserInfo
+	err = parseKeyValue(content, ":", func(key, value []byte) error {
+		// See proc(5) for the format of /proc/[pid]/status
+		switch string(key) {
+		case "Uid":
+			ids := strings.Split(string(value), "\t")
+			user.UID = ids[0]
+			user.EUID = ids[1]
+			user.SUID = ids[2]
+		case "Gid":
+			ids := strings.Split(string(value), "\t")
+			user.GID = ids[0]
+			user.EGID = ids[1]
+			user.SGID = ids[2]
+		}
+		return nil
+	})
+
+	return user, nil
 }
 
 func ticksToDuration(ticks uint64) time.Duration {

--- a/providers/linux/process_linux.go
+++ b/providers/linux/process_linux.go
@@ -217,14 +217,14 @@ func (p *process) User() (types.UserInfo, error) {
 		switch string(key) {
 		case "Uid":
 			ids := strings.Split(string(value), "\t")
-			user.UID = ids[0]
-			user.EUID = ids[1]
-			user.SUID = ids[2]
+			user.Uid = ids[0]
+			user.Euid = ids[1]
+			user.Suid = ids[2]
 		case "Gid":
 			ids := strings.Split(string(value), "\t")
-			user.GID = ids[0]
-			user.EGID = ids[1]
-			user.SGID = ids[2]
+			user.Gid = ids[0]
+			user.Egid = ids[1]
+			user.Sgid = ids[2]
 		}
 		return nil
 	})

--- a/providers/linux/process_linux.go
+++ b/providers/linux/process_linux.go
@@ -217,14 +217,18 @@ func (p *process) User() (types.UserInfo, error) {
 		switch string(key) {
 		case "Uid":
 			ids := strings.Split(string(value), "\t")
-			user.UID = ids[0]
-			user.EUID = ids[1]
-			user.SUID = ids[2]
+			if len(ids) >= 3 {
+				user.UID = ids[0]
+				user.EUID = ids[1]
+				user.SUID = ids[2]
+			}
 		case "Gid":
 			ids := strings.Split(string(value), "\t")
-			user.GID = ids[0]
-			user.EGID = ids[1]
-			user.SGID = ids[2]
+			if len(ids) >= 3 {
+				user.GID = ids[0]
+				user.EGID = ids[1]
+				user.SGID = ids[2]
+			}
 		}
 		return nil
 	})

--- a/providers/linux/process_linux.go
+++ b/providers/linux/process_linux.go
@@ -217,14 +217,14 @@ func (p *process) User() (types.UserInfo, error) {
 		switch string(key) {
 		case "Uid":
 			ids := strings.Split(string(value), "\t")
-			user.Uid = ids[0]
-			user.Euid = ids[1]
-			user.Suid = ids[2]
+			user.UID = ids[0]
+			user.EUID = ids[1]
+			user.SUID = ids[2]
 		case "Gid":
 			ids := strings.Split(string(value), "\t")
-			user.Gid = ids[0]
-			user.Egid = ids[1]
-			user.Sgid = ids[2]
+			user.GID = ids[0]
+			user.EGID = ids[1]
+			user.SGID = ids[2]
 		}
 		return nil
 	})

--- a/providers/windows/process_windows.go
+++ b/providers/windows/process_windows.go
@@ -276,8 +276,8 @@ func (p *process) User() (types.UserInfo, error) {
 	}
 
 	return types.UserInfo{
-		Uid: sid,
-		Gid: gsid,
+		UID: sid,
+		GID: gsid,
 	}, nil
 }
 

--- a/providers/windows/process_windows.go
+++ b/providers/windows/process_windows.go
@@ -271,8 +271,8 @@ func (p *process) User() (types.UserInfo, error) {
 	}
 
 	return types.UserInfo{
-		UID: sid,
-		GID: gsid,
+		Uid: sid,
+		Gid: gsid,
 	}, nil
 }
 

--- a/providers/windows/process_windows.go
+++ b/providers/windows/process_windows.go
@@ -248,10 +248,10 @@ func (p *process) User() (types.UserInfo, error) {
 	}
 	defer syscall.CloseHandle(handle)
 
-	// Filling types.UserInfo
-	var token syswin.Token
-	syswin.OpenProcessToken(syswin.Handle(handle), syscall.TOKEN_QUERY, &token)
-	tokenUser, err := token.GetTokenUser()
+	var accessToken syswin.Token
+	syswin.OpenProcessToken(syswin.Handle(handle), syscall.TOKEN_QUERY, &accessToken)
+	defer accessToken.Close()
+	tokenUser, err := accessToken.GetTokenUser()
 	if err != nil {
 		return types.UserInfo{}, errors.Wrapf(err, "GetTokenUser failed for PID %v", p.pid)
 	}
@@ -261,7 +261,7 @@ func (p *process) User() (types.UserInfo, error) {
 		return types.UserInfo{}, errors.Wrapf(err, "failed to look up user SID for PID %v", p.pid)
 	}
 
-	tokenGroup, err := token.GetTokenPrimaryGroup()
+	tokenGroup, err := accessToken.GetTokenPrimaryGroup()
 	if err != nil {
 		return types.UserInfo{}, errors.Wrapf(err, "GetTokenPrimaryGroup failed for PID %v", p.pid)
 	}

--- a/system_test.go
+++ b/system_test.go
@@ -142,12 +142,12 @@ func TestSelf(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.EqualValues(t, currentUser.Uid, user.UID)
-	assert.EqualValues(t, currentUser.Gid, user.GID)
+	assert.EqualValues(t, currentUser.Uid, user.Uid)
+	assert.EqualValues(t, currentUser.Gid, user.Gid)
 
 	if runtime.GOOS != "windows" {
-		assert.EqualValues(t, strconv.Itoa(os.Geteuid()), user.EUID)
-		assert.EqualValues(t, strconv.Itoa(os.Getegid()), user.EGID)
+		assert.EqualValues(t, strconv.Itoa(os.Geteuid()), user.Euid)
+		assert.EqualValues(t, strconv.Itoa(os.Getegid()), user.Egid)
 	}
 
 	if v, ok := process.(types.Environment); ok {

--- a/system_test.go
+++ b/system_test.go
@@ -20,6 +20,7 @@ package sysinfo
 import (
 	"encoding/json"
 	"os"
+	osUser "os/user"
 	"runtime"
 	"strconv"
 	"strings"
@@ -136,10 +137,18 @@ func TestSelf(t *testing.T) {
 		t.Fatal(err)
 	}
 	output["process.user"] = user
-	assert.EqualValues(t, strconv.Itoa(os.Getuid()), user.UID)
-	assert.EqualValues(t, strconv.Itoa(os.Geteuid()), user.EUID)
-	assert.EqualValues(t, strconv.Itoa(os.Getgid()), user.GID)
-	assert.EqualValues(t, strconv.Itoa(os.Getegid()), user.EGID)
+
+	currentUser, err := osUser.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.EqualValues(t, currentUser.Uid, user.UID)
+	assert.EqualValues(t, currentUser.Gid, user.GID)
+
+	if runtime.GOOS != "windows" {
+		assert.EqualValues(t, strconv.Itoa(os.Geteuid()), user.EUID)
+		assert.EqualValues(t, strconv.Itoa(os.Getegid()), user.EGID)
+	}
 
 	if v, ok := process.(types.Environment); ok {
 		expectedEnv := map[string]string{}

--- a/system_test.go
+++ b/system_test.go
@@ -142,12 +142,12 @@ func TestSelf(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.EqualValues(t, currentUser.Uid, user.Uid)
-	assert.EqualValues(t, currentUser.Gid, user.Gid)
+	assert.EqualValues(t, currentUser.Uid, user.UID)
+	assert.EqualValues(t, currentUser.Gid, user.GID)
 
 	if runtime.GOOS != "windows" {
-		assert.EqualValues(t, strconv.Itoa(os.Geteuid()), user.Euid)
-		assert.EqualValues(t, strconv.Itoa(os.Getegid()), user.Egid)
+		assert.EqualValues(t, strconv.Itoa(os.Geteuid()), user.EUID)
+		assert.EqualValues(t, strconv.Itoa(os.Getegid()), user.EGID)
 	}
 
 	if v, ok := process.(types.Environment); ok {

--- a/system_test.go
+++ b/system_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -129,6 +130,16 @@ func TestSelf(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.WithinDuration(t, info.StartTime, time.Now(), 10*time.Second)
+
+	user, err := process.User()
+	if err != nil {
+		t.Fatal(err)
+	}
+	output["process.user"] = user
+	assert.EqualValues(t, strconv.Itoa(os.Getuid()), user.UID)
+	assert.EqualValues(t, strconv.Itoa(os.Geteuid()), user.EUID)
+	assert.EqualValues(t, strconv.Itoa(os.Getgid()), user.GID)
+	assert.EqualValues(t, strconv.Itoa(os.Getegid()), user.EGID)
 
 	if v, ok := process.(types.Environment); ok {
 		expectedEnv := map[string]string{}

--- a/types/process.go
+++ b/types/process.go
@@ -39,33 +39,33 @@ type ProcessInfo struct {
 // UserInfo contains information about the UID and GID
 // values of a process.
 type UserInfo struct {
-	// Uid is the user ID.
+	// UID is the user ID.
 	// On Linux and Darwin (macOS) this is the real user ID.
 	// On Windows, this is the security identifier (SID) of the
 	// user account of the process access token.
-	Uid string `json:"uid"`
+	UID string `json:"uid"`
 
 	// On Linux and Darwin (macOS) this is the effective user ID.
 	// On Windows, this is empty.
-	Euid string `json:"euid"`
+	EUID string `json:"euid"`
 
 	// On Linux and Darwin (macOS) this is the saved user ID.
 	// On Windows, this is empty.
-	Suid string `json:"suid"`
+	SUID string `json:"suid"`
 
-	// Gid is the primary group ID.
+	// GID is the primary group ID.
 	// On Linux and Darwin (macOS) this is the real group ID.
 	// On Windows, this is the security identifier (SID) of the
 	// primary group of the process access token.
-	Gid string `json:"gid"`
+	GID string `json:"gid"`
 
 	// On Linux and Darwin (macOS) this is the effective group ID.
 	// On Windows, this is empty.
-	Egid string `json:"egid"`
+	EGID string `json:"egid"`
 
 	// On Linux and Darwin (macOS) this is the saved group ID.
 	// On Windows, this is empty.
-	Sgid string `json:"sgid"`
+	SGID string `json:"sgid"`
 }
 
 type Environment interface {

--- a/types/process.go
+++ b/types/process.go
@@ -23,6 +23,7 @@ type Process interface {
 	CPUTimer
 	Info() (ProcessInfo, error)
 	Memory() (MemoryInfo, error)
+	User() (UserInfo, error)
 }
 
 type ProcessInfo struct {
@@ -33,12 +34,17 @@ type ProcessInfo struct {
 	Exe       string    `json:"exe"`
 	Args      []string  `json:"args"`
 	StartTime time.Time `json:"start_time"`
-	UID       string    `json:"uid"`
-	RUID      string    `json:"ruid"`
-	SVUID     string    `json:"svuid"`
-	GID       string    `json:"gid"`
-	RGID      string    `json:"rgid"`
-	SVGID     string    `json:"svgid"`
+}
+
+// UserInfo contains information about the UID and GID
+// values of a process.
+type UserInfo struct {
+	UID  string `json:"uid"`  /* real user ID */
+	EUID string `json:"euid"` /* effective user ID */
+	SUID string `json:"suid"` /* saved user ID */
+	GID  string `json:"gid"`  /* real group ID */
+	EGID string `json:"egid"` /* effective group ID */
+	SGID string `json:"sgid"` /* saved group ID */
 }
 
 type Environment interface {

--- a/types/process.go
+++ b/types/process.go
@@ -33,6 +33,12 @@ type ProcessInfo struct {
 	Exe       string    `json:"exe"`
 	Args      []string  `json:"args"`
 	StartTime time.Time `json:"start_time"`
+	UID       string    `json:"uid"`
+	RUID      string    `json:"ruid"`
+	SVUID     string    `json:"svuid"`
+	GID       string    `json:"gid"`
+	RGID      string    `json:"rgid"`
+	SVGID     string    `json:"svgid"`
 }
 
 type Environment interface {

--- a/types/process.go
+++ b/types/process.go
@@ -39,10 +39,10 @@ type ProcessInfo struct {
 // UserInfo contains information about the UID and GID
 // values of a process.
 type UserInfo struct {
-	UID  string `json:"uid"`  /* real user ID */
+	UID  string `json:"uid"`  /* real user ID (user SID on Windows) */
 	EUID string `json:"euid"` /* effective user ID */
 	SUID string `json:"suid"` /* saved user ID */
-	GID  string `json:"gid"`  /* real group ID */
+	GID  string `json:"gid"`  /* real group ID (primary group SID on Windows) */
 	EGID string `json:"egid"` /* effective group ID */
 	SGID string `json:"sgid"` /* saved group ID */
 }

--- a/types/process.go
+++ b/types/process.go
@@ -39,12 +39,31 @@ type ProcessInfo struct {
 // UserInfo contains information about the UID and GID
 // values of a process.
 type UserInfo struct {
-	UID  string `json:"uid"`  /* real user ID (user SID on Windows) */
-	EUID string `json:"euid"` /* effective user ID */
-	SUID string `json:"suid"` /* saved user ID */
-	GID  string `json:"gid"`  /* real group ID (primary group SID on Windows) */
-	EGID string `json:"egid"` /* effective group ID */
-	SGID string `json:"sgid"` /* saved group ID */
+	// Uid is the user ID.
+	// On Linux and Darwin (macOS) this is the real user ID.
+	// On Windows, this is a security identifier (SID).
+	Uid string `json:"uid"`
+
+	// On Linux and Darwin (macOS) this is the effective user ID.
+	// On Windows, this is empty.
+	Euid string `json:"euid"`
+
+	// On Linux and Darwin (macOS) this is the saved user ID.
+	// On Windows, this is empty.
+	Suid string `json:"suid"`
+
+	// Gid is the primary group ID.
+	// On Linux and Darwin (macOS) this is the real group ID.
+	// On Windows, this is a security identifier (SID).
+	Gid string `json:"gid"`
+
+	// On Linux and Darwin (macOS) this is the effective group ID.
+	// On Windows, this is empty.
+	Egid string `json:"egid"`
+
+	// On Linux and Darwin (macOS) this is the saved group ID.
+	// On Windows, this is empty.
+	Sgid string `json:"sgid"`
 }
 
 type Environment interface {

--- a/types/process.go
+++ b/types/process.go
@@ -41,7 +41,8 @@ type ProcessInfo struct {
 type UserInfo struct {
 	// Uid is the user ID.
 	// On Linux and Darwin (macOS) this is the real user ID.
-	// On Windows, this is a security identifier (SID).
+	// On Windows, this is the security identifier (SID) of the
+	// user account of the process access token.
 	Uid string `json:"uid"`
 
 	// On Linux and Darwin (macOS) this is the effective user ID.
@@ -54,7 +55,8 @@ type UserInfo struct {
 
 	// Gid is the primary group ID.
 	// On Linux and Darwin (macOS) this is the real group ID.
-	// On Windows, this is a security identifier (SID).
+	// On Windows, this is the security identifier (SID) of the
+	// primary group of the process access token.
 	Gid string `json:"gid"`
 
 	// On Linux and Darwin (macOS) this is the effective group ID.


### PR DESCRIPTION
Adds a `User()` function to `Process` and implements it for all providers.

For Linux and Darwin (macOS) this retrieves the real, effective, and saved user and group IDs.

For Windows, this retrieves the user and primary group SID.

It does not retrieve the Linux-specific filesystem UID and GID because its use has been deprecated for a long time (since 1995, I believe).

Closes https://github.com/elastic/go-sysinfo/issues/10.