### PR TITLE
Optimize Processes()

### DIFF
--- a/providers/linux/process_linux.go
+++ b/providers/linux/process_linux.go
@@ -37,7 +37,6 @@ func (s linuxSystem) Processes() ([]types.Process, error) {
 	if err != nil {
 		return nil, err
 	}
-	s.procFS.Path()
 
 	processes := make([]types.Process, 0, len(procs))
 	for _, proc := range procs {

--- a/providers/windows/process_windows.go
+++ b/providers/windows/process_windows.go
@@ -46,6 +46,12 @@ func (s windowsSystem) Processes() (procs []types.Process, err error) {
 	procs = make([]types.Process, 0, len(pids))
 	var proc types.Process
 	for _, pid := range pids {
+		if pid == 0 || pid == 4 {
+			// The Idle and System processes (PIDs 0 and 4) can never be
+			// opened by user-level code (see documentation for OpenProcess).
+			continue
+		}
+
 		if proc, err = s.Process(int(pid)); err == nil {
 			procs = append(procs, proc)
 		}


### PR DESCRIPTION
Removing a line of unneeded code in `Processes()` for Linux, and skipping trying (and always failing) to open the Idle and System processes on Windows.