### PR TITLE
Add Process.PID()

### DIFF
--- a/providers/darwin/process_darwin_amd64.go
+++ b/providers/darwin/process_darwin_amd64.go
@@ -61,6 +61,10 @@ type process struct {
 	env  map[string]string
 }
 
+func (p *process) PID() int {
+	return p.pid
+}
+
 func (p *process) Info() (types.ProcessInfo, error) {
 	var task procTaskAllInfo
 	if err := getProcTaskAllInfo(p.pid, &task); err != nil {

--- a/providers/linux/process_linux.go
+++ b/providers/linux/process_linux.go
@@ -69,8 +69,12 @@ type process struct {
 	info *types.ProcessInfo
 }
 
+func (p *process) PID() int {
+	return p.Proc.PID
+}
+
 func (p *process) path(pa ...string) string {
-	return p.fs.Path(append([]string{strconv.Itoa(p.PID)}, pa...)...)
+	return p.fs.Path(append([]string{strconv.Itoa(p.PID())}, pa...)...)
 }
 
 func (p *process) CWD() (string, error) {
@@ -115,7 +119,7 @@ func (p *process) Info() (types.ProcessInfo, error) {
 
 	p.info = &types.ProcessInfo{
 		Name:      stat.Comm,
-		PID:       p.PID,
+		PID:       p.PID(),
 		PPID:      stat.PPID,
 		CWD:       cwd,
 		Exe:       exe,

--- a/providers/windows/process_windows.go
+++ b/providers/windows/process_windows.go
@@ -75,6 +75,10 @@ type process struct {
 	info types.ProcessInfo
 }
 
+func (p *process) PID() int {
+	return p.pid
+}
+
 func newProcess(pid int) (*process, error) {
 	p := &process{pid: pid}
 	if err := p.init(); err != nil {

--- a/system_test.go
+++ b/system_test.go
@@ -96,6 +96,7 @@ func TestSelf(t *testing.T) {
 	} else if err != nil {
 		t.Fatal(err)
 	}
+	assert.EqualValues(t, os.Getpid(), process.PID())
 
 	if runtime.GOOS == "linux" {
 		// Do some dummy work to spend user CPU time.

--- a/types/process.go
+++ b/types/process.go
@@ -24,6 +24,7 @@ type Process interface {
 	Info() (ProcessInfo, error)
 	Memory() (MemoryInfo, error)
 	User() (UserInfo, error)
+	PID() int
 }
 
 type ProcessInfo struct {


### PR DESCRIPTION
Adds a `PID()` method to `Process` and implements it for all providers.

The main purpose is error handling, e.g.::
```
procs := sysinfo.Processes()
for _, p := range procs {
  info, err := p.Info()
  if err != nil {
    return errors.Errorf("error encountered for PID %v", p.PID())
  }
  [...]
}
```

Note, unlike the other methods of `Process`, `PID()` cannot return an error.