### PR TITLE
Return not containerized if /proc/1/cgroup does not exist

### DIFF
--- a/providers/linux/container.go
+++ b/providers/linux/container.go
@@ -21,6 +21,7 @@ import (
 	"bufio"
 	"bytes"
 	"io/ioutil"
+	"os"
 
 	"github.com/pkg/errors"
 )
@@ -31,6 +32,10 @@ const procOneCgroup = "/proc/1/cgroup"
 func IsContainerized() (bool, error) {
 	data, err := ioutil.ReadFile(procOneCgroup)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+
 		return false, errors.Wrap(err, "failed to read process cgroups")
 	}
 


### PR DESCRIPTION
We check the contents of `/proc/1/cgroup` to determine if we are in a container or not. However, this pseudo file will not exist if cgroup is not available, e.g. if it has been explicitly disabled, maybe on a shared system. This PR returns `false` (i.e. not containerized) if the file does not exist.

This has been reported [on SO](https://stackoverflow.com/questions/53542451/elastic-filebeat-6-5-1-error-failed-to-read-process-cgroups), and we fixed a similar issue in Beats (https://github.com/elastic/beats/issues/3666).