### PR TITLE
Check for docker or lxc in /proc/1/cgroup

### DIFF
--- a/providers/linux/container.go
+++ b/providers/linux/container.go
@@ -46,14 +46,13 @@ func isContainerizedCgroup(data []byte) (bool, error) {
 	s := bufio.NewScanner(bytes.NewReader(data))
 	for n := 0; s.Scan(); n++ {
 		line := s.Bytes()
-		if len(line) == 0 || line[len(line)-1] == '/' {
-			continue
-		}
 
-		if bytes.HasSuffix(line, []byte("init.scope")) {
-			return false, nil
+		// Following a suggestion on Stack Overflow on how to detect
+		// being inside a container: https://stackoverflow.com/a/20012536/235203
+		if bytes.Contains(line, []byte("docker")) || bytes.Contains(line, []byte("lxc")) {
+			return true, nil
 		}
 	}
 
-	return true, s.Err()
+	return false, s.Err()
 }

--- a/providers/linux/container_test.go
+++ b/providers/linux/container_test.go
@@ -68,6 +68,16 @@ const containerHostPIDNamespaceCgroup = `14:name=systemd:/
 1:name=openrc:/
 `
 
+const lxcCgroup = `9:hugetlb:/lxc/81438f4655cd771c425607dcf7654f4dc03c073c0123edc45fcfad28132e8c60
+8:perf_event:/lxc/81438f4655cd771c425607dcf7654f4dc03c073c0123edc45fcfad28132e8c60
+7:blkio:/lxc/81438f4655cd771c425607dcf7654f4dc03c073c0123edc45fcfad28132e8c60
+6:freezer:/lxc/81438f4655cd771c425607dcf7654f4dc03c073c0123edc45fcfad28132e8c60
+5:devices:/lxc/81438f4655cd771c425607dcf7654f4dc03c073c0123edc45fcfad28132e8c60
+4:memory:/lxc/81438f4655cd771c425607dcf7654f4dc03c073c0123edc45fcfad28132e8c60
+3:cpuacct:/lxc/81438f4655cd771c425607dcf7654f4dc03c073c0123edc45fcfad28132e8c60
+2:cpu:/lxc/81438f4655cd771c425607dcf7654f4dc03c073c0123edc45fcfad28132e8c60
+1:cpuset:/lxc/81438f4655cd771c425607dcf7654f4dc03c073c0123edc45fcfad28132e8c60`
+
 const emptyCgroup = ``
 
 func TestIsContainerized(t *testing.T) {
@@ -88,6 +98,12 @@ func TestIsContainerized(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.False(t, containerized)
+
+	containerized, err = isContainerizedCgroup([]byte(lxcCgroup))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.True(t, containerized)
 
 	containerized, err = isContainerizedCgroup([]byte(emptyCgroup))
 	if err != nil {

--- a/providers/linux/container_test.go
+++ b/providers/linux/container_test.go
@@ -68,6 +68,8 @@ const containerHostPIDNamespaceCgroup = `14:name=systemd:/
 1:name=openrc:/
 `
 
+const emptyCgroup = ``
+
 func TestIsContainerized(t *testing.T) {
 	containerized, err := isContainerizedCgroup([]byte(nonContainerizedCgroup))
 	if err != nil {
@@ -85,5 +87,11 @@ func TestIsContainerized(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.True(t, containerized)
+	assert.False(t, containerized)
+
+	containerized, err = isContainerizedCgroup([]byte(emptyCgroup))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.False(t, containerized)
 }


### PR DESCRIPTION
Instead of relying on `init.scope` being present in `/proc/1/cgroup` this changes to checking for the strings `docker` and `lxc` as [proposed on SO](https://stackoverflow.com/a/20012536/235203).

Two other notes:
1. Changes the default to be not containerized, e.g. if the pseudo file is empty (it is on my CentOS 6).
2. Fixes a bug incl. a test case where if all paths are `/` it should be NOT containerized. The code seemed to explicitly try to achieve the opposite. The SO answer above calls out this situation. I'm wondering if I'm overlooking something, or if the code and test case were just wrong.

Fixes https://github.com/elastic/go-sysinfo/issues/11.