### PR TITLE
Linux: Check historic machine-id files

### DIFF
--- a/providers/linux/machineid.go
+++ b/providers/linux/machineid.go
@@ -27,11 +27,37 @@ import (
 	"github.com/elastic/go-sysinfo/types"
 )
 
+var (
+	// Possible (current and historic) locations of the machine-id file.
+	// These will be searched in order.
+	machineIdFiles = []string{"/etc/machine-id", "/var/lib/dbus/machine-id", "/var/db/dbus/machine-id"}
+)
+
 func MachineID() (string, error) {
-	id, err := ioutil.ReadFile("/etc/machine-id")
+	var contents []byte
+	var err error
+
+	for _, file := range machineIdFiles {
+		contents, err = ioutil.ReadFile(file)
+		if err != nil {
+			if os.IsNotExist(err) {
+				// Try next location
+				continue
+			}
+
+			// Return with error on any other error
+			return "", errors.Wrapf(err, "failed to read %v", file)
+		} else {
+			// Found it
+			break
+		}
+	}
+
 	if os.IsNotExist(err) {
+		// None of the locations existed
 		return "", types.ErrNotImplemented
 	}
-	id = bytes.TrimSpace(id)
-	return string(id), errors.Wrap(err, "failed to read machine-id")
+
+	contents = bytes.TrimSpace(contents)
+	return string(contents), nil
 }

--- a/providers/linux/machineid.go
+++ b/providers/linux/machineid.go
@@ -30,14 +30,14 @@ import (
 var (
 	// Possible (current and historic) locations of the machine-id file.
 	// These will be searched in order.
-	machineIdFiles = []string{"/etc/machine-id", "/var/lib/dbus/machine-id", "/var/db/dbus/machine-id"}
+	machineIDFiles = []string{"/etc/machine-id", "/var/lib/dbus/machine-id", "/var/db/dbus/machine-id"}
 )
 
 func MachineID() (string, error) {
 	var contents []byte
 	var err error
 
-	for _, file := range machineIdFiles {
+	for _, file := range machineIDFiles {
 		contents, err = ioutil.ReadFile(file)
 		if err != nil {
 			if os.IsNotExist(err) {

--- a/providers/linux/machineid.go
+++ b/providers/linux/machineid.go
@@ -47,10 +47,10 @@ func MachineID() (string, error) {
 
 			// Return with error on any other error
 			return "", errors.Wrapf(err, "failed to read %v", file)
-		} else {
-			// Found it
-			break
 		}
+
+		// Found it
+		break
 	}
 
 	if os.IsNotExist(err) {

--- a/system_test.go
+++ b/system_test.go
@@ -234,6 +234,7 @@ func TestHost(t *testing.T) {
 
 	info := host.Info()
 	assert.NotZero(t, info)
+	assert.NotZero(t, info.UniqueID)
 
 	memory, err := host.Memory()
 	if err != nil {


### PR DESCRIPTION
Historically, the `machine-id` was not always in `/etc/machine-id`. On Ubuntu 14.04, it is still in `/var/lib/dbus/machine-id`. Another possible location is `/var/db/dbus/machine-id`.

This checks these three locations in order and returns the first ID it finds.