### PR TITLE
Add Process.Parent()

### DIFF
--- a/providers/linux/os_test.go
+++ b/providers/linux/os_test.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build linux
+
 package linux
 
 import (

--- a/providers/linux/os_test.go
+++ b/providers/linux/os_test.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build linux
+// +build !windows
 
 package linux
 

--- a/providers/linux/process_linux.go
+++ b/providers/linux/process_linux.go
@@ -73,6 +73,20 @@ func (p *process) PID() int {
 	return p.Proc.PID
 }
 
+func (p *process) Parent() (types.Process, error) {
+	info, err := p.Info()
+	if err != nil {
+		return nil, err
+	}
+
+	proc, err := p.fs.NewProc(info.PPID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &process{Proc: proc, fs: p.fs}, nil
+}
+
 func (p *process) path(pa ...string) string {
 	return p.fs.Path(append([]string{strconv.Itoa(p.PID())}, pa...)...)
 }

--- a/providers/windows/process_windows.go
+++ b/providers/windows/process_windows.go
@@ -79,6 +79,15 @@ func (p *process) PID() int {
 	return p.pid
 }
 
+func (p *process) Parent() (types.Process, error) {
+	info, err := p.Info()
+	if err != nil {
+		return nil, err
+	}
+
+	return newProcess(info.PPID)
+}
+
 func newProcess(pid int) (*process, error) {
 	p := &process{pid: pid}
 	if err := p.init(); err != nil {

--- a/system_test.go
+++ b/system_test.go
@@ -115,6 +115,7 @@ func TestSelf(t *testing.T) {
 	assert.EqualValues(t, os.Getpid(), info.PID)
 	assert.EqualValues(t, os.Getppid(), info.PPID)
 	assert.Equal(t, os.Args, info.Args)
+	assert.WithinDuration(t, info.StartTime, time.Now(), 10*time.Second)
 
 	wd, err := os.Getwd()
 	if err != nil {
@@ -128,10 +129,11 @@ func TestSelf(t *testing.T) {
 	}
 	assert.Equal(t, exe, info.Exe)
 
+	parent, err := process.Parent()
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.WithinDuration(t, info.StartTime, time.Now(), 10*time.Second)
+	assert.EqualValues(t, os.Getppid(), parent.PID())
 
 	user, err := process.User()
 	if err != nil {

--- a/types/process.go
+++ b/types/process.go
@@ -24,6 +24,7 @@ type Process interface {
 	Info() (ProcessInfo, error)
 	Memory() (MemoryInfo, error)
 	User() (UserInfo, error)
+	Parent() (Process, error)
 	PID() int
 }
 


### PR DESCRIPTION
Adds a `Parent()` method to `Process` and implements it for all platforms. This should make it easier for users of this library to traverse the process tree.

Two other minor changes:
1. Caches the result of `Info()` on Darwin. We already do this for Linux and Windows, and now that `Parent()` is calling `Info()` as well it makes even more sense to cache.
2. Adds a build constraint to `providers/linux/os_test.go` - unlike many other test files that contain `_linux` in their names and are thus excluded, this one had been running on Windows as well. At least on my Windows Vagrant machine `go test ./...` failed because of it.