### PR TITLE
providers/linux: fixes for new prometheus/procfs

### DIFF
--- a/providers/linux/process_linux.go
+++ b/providers/linux/process_linux.go
@@ -65,7 +65,7 @@ func (s linuxSystem) Self() (types.Process, error) {
 
 type process struct {
 	procfs.Proc
-	fs   procfs.FS
+	fs   procFS
 	info *types.ProcessInfo
 }
 
@@ -88,7 +88,7 @@ func (p *process) Parent() (types.Process, error) {
 }
 
 func (p *process) path(pa ...string) string {
-	return p.fs.Path(append([]string{strconv.Itoa(p.PID())}, pa...)...)
+	return p.fs.path(append([]string{strconv.Itoa(p.PID())}, pa...)...)
 }
 
 func (p *process) CWD() (string, error) {
@@ -126,7 +126,7 @@ func (p *process) Info() (types.ProcessInfo, error) {
 		return types.ProcessInfo{}, err
 	}
 
-	bootTime, err := bootTime(p.fs)
+	bootTime, err := bootTime(p.fs.FS)
 	if err != nil {
 		return types.ProcessInfo{}, err
 	}


### PR DESCRIPTION
Update the Linux provider to use `procfs.NewFS`, and stop using the `procfs.FS.Path` method which was removed in https://github.com/prometheus/procfs/pull/149.

The changed code works with both the old and new procfs APIs.