### PR TITLE
Fix a memory leak when using CommandLineToArgv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a leak when calling the CommandLineToArgv function. [#51](https://github.com/elastic/go-sysinfo/pull/51)
+
 ### Security
 
 ## [1.0.1] - 2019-05-08

--- a/providers/windows/process_windows.go
+++ b/providers/windows/process_windows.go
@@ -229,6 +229,10 @@ func splitCommandline(utf16 []byte) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Free memory allocated for CommandLineToArgvW arguments.
+	defer syscall.LocalFree((syscall.Handle)(unsafe.Pointer(argsWide)))
+
 	args := make([]string, numArgs)
 	for idx := range args {
 		args[idx] = syscall.UTF16ToString(argsWide[idx][:])


### PR DESCRIPTION
A call to LocalFree is needed to deallocate the returned buffer.