### PR TITLE
prometheus dependency bug when building in linux fix

### DIFF
--- a/providers/linux/boottime_linux.go
+++ b/providers/linux/boottime_linux.go
@@ -37,7 +37,7 @@ func bootTime(fs procfs.FS) (time.Time, error) {
 		return bootTimeValue, nil
 	}
 
-	stat, err := fs.NewStat()
+	stat, err := procfs.NewStat()
 	if err != nil {
 		return time.Time{}, err
 	}

--- a/providers/linux/boottime_linux.go
+++ b/providers/linux/boottime_linux.go
@@ -37,7 +37,7 @@ func bootTime(fs procfs.FS) (time.Time, error) {
 		return bootTimeValue, nil
 	}
 
-	stat, err := procfs.NewStat()
+	stat, err := fs.Stat()
 	if err != nil {
 		return time.Time{}, err
 	}

--- a/providers/linux/boottime_linux.go
+++ b/providers/linux/boottime_linux.go
@@ -20,8 +20,6 @@ package linux
 import (
 	"sync"
 	"time"
-
-	"github.com/prometheus/procfs"
 )
 
 var (
@@ -29,7 +27,7 @@ var (
 	bootTimeLock  sync.Mutex // Lock that guards access to bootTime.
 )
 
-func bootTime(fs procfs.FS) (time.Time, error) {
+func bootTime(fs procFS) (time.Time, error) {
 	bootTimeLock.Lock()
 	defer bootTimeLock.Unlock()
 

--- a/providers/linux/host_linux.go
+++ b/providers/linux/host_linux.go
@@ -90,7 +90,7 @@ func (h *host) CPUTime() (types.CPUTimes, error) {
 }
 
 func newHost(fs procFS) (*host, error) {
-	stat, err := procfs.NewStat()
+	stat, err := fs.Stat()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read proc stat")
 	}

--- a/providers/linux/host_linux.go
+++ b/providers/linux/host_linux.go
@@ -72,7 +72,7 @@ func (h *host) Memory() (*types.HostMemoryInfo, error) {
 }
 
 func (h *host) CPUTime() (types.CPUTimes, error) {
-	stat, err := h.procFS.NewStat()
+	stat, err := procfs.NewStat()
 	if err != nil {
 		return types.CPUTimes{}, err
 	}
@@ -90,7 +90,7 @@ func (h *host) CPUTime() (types.CPUTimes, error) {
 }
 
 func newHost(fs procFS) (*host, error) {
-	stat, err := fs.NewStat()
+	stat, err := procfs.NewStat()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read proc stat")
 	}

--- a/providers/linux/host_linux.go
+++ b/providers/linux/host_linux.go
@@ -72,7 +72,7 @@ func (h *host) Memory() (*types.HostMemoryInfo, error) {
 }
 
 func (h *host) CPUTime() (types.CPUTimes, error) {
-	stat, err := procfs.NewStat()
+	stat, err := h.procFS.Stat()
 	if err != nil {
 		return types.CPUTimes{}, err
 	}

--- a/providers/linux/process_linux.go
+++ b/providers/linux/process_linux.go
@@ -79,7 +79,7 @@ func (p *process) Parent() (types.Process, error) {
 		return nil, err
 	}
 
-	proc, err := procfs.NewProc(info.PPID)
+	proc, err := p.fs.Proc(info.PPID)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/linux/process_linux.go
+++ b/providers/linux/process_linux.go
@@ -46,7 +46,7 @@ func (s linuxSystem) Processes() ([]types.Process, error) {
 }
 
 func (s linuxSystem) Process(pid int) (types.Process, error) {
-	proc, err := s.procFS.NewProc(pid)
+	proc, err := procfs.NewProc(pid)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func (p *process) Parent() (types.Process, error) {
 		return nil, err
 	}
 
-	proc, err := p.fs.NewProc(info.PPID)
+	proc, err := procfs.NewProc(info.PPID)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/linux/process_linux.go
+++ b/providers/linux/process_linux.go
@@ -46,7 +46,7 @@ func (s linuxSystem) Processes() ([]types.Process, error) {
 }
 
 func (s linuxSystem) Process(pid int) (types.Process, error) {
-	proc, err := procfs.NewProc(pid)
+	proc, err := s.procFS.Proc(pid)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/linux/process_linux.go
+++ b/providers/linux/process_linux.go
@@ -126,7 +126,7 @@ func (p *process) Info() (types.ProcessInfo, error) {
 		return types.ProcessInfo{}, err
 	}
 
-	bootTime, err := bootTime(p.fs.FS)
+	bootTime, err := bootTime(p.fs)
 	if err != nil {
 		return types.ProcessInfo{}, err
 	}


### PR DESCRIPTION
NewStat() method was moved from the process.FS struct to a function on the root of the prometheus/procfs package

#55 