### PR TITLE
Add godocs to to the types lib

### DIFF
--- a/types/errors.go
+++ b/types/errors.go
@@ -19,4 +19,5 @@ package types
 
 import "github.com/pkg/errors"
 
+// ErrNotImplemented represents an error for a function that is not implemented on a particular platform.
 var ErrNotImplemented = errors.New("unimplemented")

--- a/types/go.go
+++ b/types/go.go
@@ -17,6 +17,7 @@
 
 package types
 
+// GoInfo contains info about the go runtime
 type GoInfo struct {
 	OS       string `json:"os"`
 	Arch     string `json:"arch"`

--- a/types/host.go
+++ b/types/host.go
@@ -19,7 +19,7 @@ package types
 
 import "time"
 
-// Host is the main wrapper for returning Host stats
+// Host is the interface that wraps methods for returning Host stats
 type Host interface {
 	CPUTimer
 	Info() HostInfo

--- a/types/host.go
+++ b/types/host.go
@@ -19,7 +19,7 @@ package types
 
 import "time"
 
-// Host is the interface type for gathering host data
+// Host is the main wrapper for returning Host stats
 type Host interface {
 	CPUTimer
 	Info() HostInfo
@@ -59,7 +59,8 @@ type OSInfo struct {
 	Codename string `json:"codename,omitempty"` // OS codename (e.g. jessie).
 }
 
-// LoadAverage is the interface type that returns load info on the host
+// LoadAverage is the interface that wraps the LoadAverage method.
+// LoadAverage returns load info on the host
 type LoadAverage interface {
 	LoadAverage() LoadAverageInfo
 }

--- a/types/host.go
+++ b/types/host.go
@@ -19,12 +19,14 @@ package types
 
 import "time"
 
+// Host is the interface type for gathering host data
 type Host interface {
 	CPUTimer
 	Info() HostInfo
 	Memory() (*HostMemoryInfo, error)
 }
 
+// HostInfo contains basic host information
 type HostInfo struct {
 	Architecture      string    `json:"architecture"`            // Hardware architecture (e.g. x86_64, arm, ppc, mips).
 	BootTime          time.Time `json:"boot_time"`               // Host boot time.
@@ -39,10 +41,12 @@ type HostInfo struct {
 	UniqueID          string    `json:"id,omitempty"`            // Unique ID of the host (optional).
 }
 
+// Uptime returns the system uptime
 func (host HostInfo) Uptime() time.Duration {
 	return time.Since(host.BootTime)
 }
 
+// OSInfo contains basic OS information
 type OSInfo struct {
 	Family   string `json:"family"`             // OS Family (e.g. redhat, debian, freebsd, windows).
 	Platform string `json:"platform"`           // OS platform (e.g. centos, ubuntu, windows).
@@ -55,10 +59,12 @@ type OSInfo struct {
 	Codename string `json:"codename,omitempty"` // OS codename (e.g. jessie).
 }
 
+// LoadAverage is the interface type that returns load info on the host
 type LoadAverage interface {
 	LoadAverage() LoadAverageInfo
 }
 
+// LoadAverageInfo contains load statistics
 type LoadAverageInfo struct {
 	One     float64 `json:"one_min"`
 	Five    float64 `json:"five_min"`

--- a/types/process.go
+++ b/types/process.go
@@ -19,6 +19,7 @@ package types
 
 import "time"
 
+// Process is the interface type for returning information on a process
 type Process interface {
 	CPUTimer
 	Info() (ProcessInfo, error)
@@ -28,6 +29,7 @@ type Process interface {
 	PID() int
 }
 
+// ProcessInfo contains basic stats about a process
 type ProcessInfo struct {
 	Name      string    `json:"name"`
 	PID       int       `json:"pid"`
@@ -70,6 +72,7 @@ type UserInfo struct {
 	SGID string `json:"sgid"`
 }
 
+// Environment is the interface type that returns the environment variables for a process
 type Environment interface {
 	Environment() (map[string]string, error)
 }
@@ -79,11 +82,12 @@ type OpenHandleEnumerator interface {
 	OpenHandles() ([]string, error)
 }
 
-// OpenHandleCount returns the number the open file handles.
+// OpenHandleCounter is the interface type returns the number the open file handles.
 type OpenHandleCounter interface {
 	OpenHandleCount() (int, error)
 }
 
+// CPUTimer is the interface type for returning CPU time info
 type CPUTimer interface {
 	// CPUTime returns a CPUTimes structure for
 	// the host or some process.
@@ -94,6 +98,7 @@ type CPUTimer interface {
 	CPUTime() (CPUTimes, error)
 }
 
+// CPUTimes contains CPU timing stats for a process
 type CPUTimes struct {
 	User    time.Duration `json:"user"`
 	System  time.Duration `json:"system"`
@@ -105,22 +110,26 @@ type CPUTimes struct {
 	Steal   time.Duration `json:"steal,omitempty"`
 }
 
+// Total returns the total CPU time
 func (cpu CPUTimes) Total() time.Duration {
 	return cpu.User + cpu.System + cpu.Idle + cpu.IOWait + cpu.IRQ + cpu.Nice +
 		cpu.SoftIRQ + cpu.Steal
 }
 
+// MemoryInfo contains memory stats for a process
 type MemoryInfo struct {
 	Resident uint64            `json:"resident_bytes"`
 	Virtual  uint64            `json:"virtual_bytes"`
 	Metrics  map[string]uint64 `json:"raw,omitempty"` // Other memory related metrics.
 }
 
+// SeccompInfo contains seccomp info for a process
 type SeccompInfo struct {
 	Mode       string `json:"mode"`
 	NoNewPrivs *bool  `json:"no_new_privs,omitempty"` // Added in kernel 4.10.
 }
 
+// CapabilityInfo contains capability set info.
 type CapabilityInfo struct {
 	Inheritable []string `json:"inheritable"`
 	Permitted   []string `json:"permitted"`
@@ -129,10 +138,12 @@ type CapabilityInfo struct {
 	Ambient     []string `json:"ambient"`
 }
 
+// Capabilities is the interface type for returning capabilities for a process
 type Capabilities interface {
 	Capabilities() (*CapabilityInfo, error)
 }
 
+// Seccomp is the interface type for returning Seccomp info
 type Seccomp interface {
 	Seccomp() (*SeccompInfo, error)
 }

--- a/types/process.go
+++ b/types/process.go
@@ -19,7 +19,7 @@ package types
 
 import "time"
 
-// Process is the interface type for returning information on a process
+// Process is the main wrapper for gathering information on a process
 type Process interface {
 	CPUTimer
 	Info() (ProcessInfo, error)
@@ -72,22 +72,26 @@ type UserInfo struct {
 	SGID string `json:"sgid"`
 }
 
-// Environment is the interface type that returns the environment variables for a process
+// Environment is the interface that wraps the Environment method.
+// Evironment returns variables for a process
 type Environment interface {
 	Environment() (map[string]string, error)
 }
 
-// OpenHandleEnumerator lists the open file handles.
+// OpenHandleEnumerator is the interface that wraps the OpenHandles method.
+// OpenHandles lists the open file handles.
 type OpenHandleEnumerator interface {
 	OpenHandles() ([]string, error)
 }
 
-// OpenHandleCounter is the interface type returns the number the open file handles.
+// OpenHandleCounter is the interface that wraps the OpenHandleCount method.
+// OpenHandleCount returns the number of open file handles.
 type OpenHandleCounter interface {
 	OpenHandleCount() (int, error)
 }
 
-// CPUTimer is the interface type for returning CPU time info
+// CPUTimer is the interface that wraps the CPUTime method.
+// CPUTime returns CPU time info
 type CPUTimer interface {
 	// CPUTime returns a CPUTimes structure for
 	// the host or some process.
@@ -138,12 +142,14 @@ type CapabilityInfo struct {
 	Ambient     []string `json:"ambient"`
 }
 
-// Capabilities is the interface type for returning capabilities for a process
+// Capabilities is the interface that wraps the Capabilities method.
+// Capabilities returns capabilities for a process
 type Capabilities interface {
 	Capabilities() (*CapabilityInfo, error)
 }
 
-// Seccomp is the interface type for returning Seccomp info
+// Seccomp is the interface that wraps the Seccomp method.
+// Seccomp returns seccomp info on Linux
 type Seccomp interface {
 	Seccomp() (*SeccompInfo, error)
 }

--- a/types/process.go
+++ b/types/process.go
@@ -73,7 +73,7 @@ type UserInfo struct {
 }
 
 // Environment is the interface that wraps the Environment method.
-// Evironment returns variables for a process
+// Environment returns variables for a process
 type Environment interface {
 	Environment() (map[string]string, error)
 }


### PR DESCRIPTION
This adds basic godocs to the types lib, so it at least runs linter-clean. I didn't want to do the entire codebase, as touching that much stuff in one PR is a tad annoying, IMO. I wasn't sure about about the verbiage I use for the interfaces, since the way this library uses its interface types is a little odd, as the user is expected to actively cast between interfaces. 