### PR TITLE
Fix for assignment mismatch in process_windows.go #67

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/procfs v0.0.0-20190425082905-87a4384529e0
 	github.com/stretchr/testify v1.3.0
-	golang.org/x/sys v0.0.0-20190425145619-16072639606e
+	golang.org/x/sys v0.0.0-20191025021431-6c3a3bfe00ae
 	howett.net/plist v0.0.0-20181124034731-591f970eefbb
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sys v0.0.0-20190425145619-16072639606e h1:4ktJgTV34+N3qOZUc5fAaG3Pb11qzMm3PkAoTAgUZ2I=
-golang.org/x/sys v0.0.0-20190425145619-16072639606e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191025021431-6c3a3bfe00ae h1:QoJmnb9uyPCrH8GIg9uRLn4Ta45yhcQtpymCd0AavO8=
+golang.org/x/sys v0.0.0-20191025021431-6c3a3bfe00ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/providers/windows/process_windows.go
+++ b/providers/windows/process_windows.go
@@ -306,7 +306,7 @@ func (p *process) User() (types.UserInfo, error) {
 
 	sid := tokenUser.User.Sid.String()
 	if sid == "" {
-		return types.UserInfo{}, errors.Wrap(err, "failed to look up user SID")
+		return types.UserInfo{}, errors.New("failed to look up user SID")
 	}
 
 	tokenGroup, err := accessToken.GetTokenPrimaryGroup()
@@ -315,7 +315,7 @@ func (p *process) User() (types.UserInfo, error) {
 	}
 	gsid := tokenGroup.PrimaryGroup.String()
 	if gsid == "" {
-		return types.UserInfo{}, errors.Wrap(err, "failed to look up primary group SID")
+		return types.UserInfo{}, errors.New("failed to look up primary group SID")
 	}
 
 	return types.UserInfo{

--- a/providers/windows/process_windows.go
+++ b/providers/windows/process_windows.go
@@ -304,8 +304,8 @@ func (p *process) User() (types.UserInfo, error) {
 		return types.UserInfo{}, errors.Wrap(err, "GetTokenUser failed")
 	}
 
-	sid, err := tokenUser.User.Sid.String()
-	if err != nil {
+	sid := tokenUser.User.Sid.String()
+	if sid == "" {
 		return types.UserInfo{}, errors.Wrap(err, "failed to look up user SID")
 	}
 
@@ -313,8 +313,8 @@ func (p *process) User() (types.UserInfo, error) {
 	if err != nil {
 		return types.UserInfo{}, errors.Wrap(err, "GetTokenPrimaryGroup failed")
 	}
-	gsid, err := tokenGroup.PrimaryGroup.String()
-	if err != nil {
+	gsid := tokenGroup.PrimaryGroup.String()
+	if gsid == "" {
 		return types.UserInfo{}, errors.Wrap(err, "failed to look up primary group SID")
 	}
 


### PR DESCRIPTION
Seems to me without this fix, by-default we can't build a Windows version of a project that uses go.elastic.co/apm. Let me know if this isn't where or how we suppose to address that.