### PR TITLE
Recognize systemd based cgroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added detection of systemd cgroups to the `IsContainerized` check. [#71](https://github.com/elastic/go-sysinfo/pull/71)
+
 ### Changed
 
 ### Deprecated

--- a/providers/linux/container.go
+++ b/providers/linux/container.go
@@ -49,7 +49,7 @@ func isContainerizedCgroup(data []byte) (bool, error) {
 
 		// Following a suggestion on Stack Overflow on how to detect
 		// being inside a container: https://stackoverflow.com/a/20012536/235203
-		if bytes.Contains(line, []byte("docker")) || bytes.Contains(line, []byte("lxc")) {
+		if bytes.Contains(line, []byte("docker")) || bytes.Contains(line, []byte(".slice")) || bytes.Contains(line, []byte("lxc")) {
 			return true, nil
 		}
 	}

--- a/providers/linux/machineid.go
+++ b/providers/linux/machineid.go
@@ -27,11 +27,9 @@ import (
 	"github.com/elastic/go-sysinfo/types"
 )
 
-var (
-	// Possible (current and historic) locations of the machine-id file.
-	// These will be searched in order.
-	machineIDFiles = []string{"/etc/machine-id", "/var/lib/dbus/machine-id", "/var/db/dbus/machine-id"}
-)
+// Possible (current and historic) locations of the machine-id file.
+// These will be searched in order.
+var machineIDFiles = []string{"/etc/machine-id", "/var/lib/dbus/machine-id", "/var/db/dbus/machine-id"}
 
 func MachineID() (string, error) {
 	var contents []byte


### PR DESCRIPTION
Systemd based cgroups like how containerd works creates entries with <namespace>.slice. In the case of kubernetes pods it would be `kubepods.slice`. This PR looks for `.slice` in addition to Docker and LXC.