### PR TITLE
Move to uint64 for procnet, deal with MaxConn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Convert NetworkCountersInfo maps to uint64 [#75](https://github.com/elastic/go-sysinfo/pull/75)
 
 ### Deprecated
 

--- a/providers/linux/procnet_test.go
+++ b/providers/linux/procnet_test.go
@@ -46,5 +46,6 @@ UdpLite: 0 0 0 0 0 0 0 0`
 	fillStruct(&testOut, mapStr)
 
 	assert.NotEmpty(t, testOut.IP)
-	assert.Equal(t, int64(16755), testOut.UDP["InDatagrams"])
+	assert.Equal(t, uint64(16755), testOut.UDP["InDatagrams"])
+	assert.Equal(t, uint64(0xffffffffffffffff), testOut.TCP["MaxConn"])
 }

--- a/types/host.go
+++ b/types/host.go
@@ -32,19 +32,20 @@ type NetworkCounters interface {
 }
 
 // SNMP represents the data from /proc/net/snmp
+// Note that according to RFC 2012,TCP.MaxConn, if present, is a signed value and should be cast to int64
 type SNMP struct {
-	IP      map[string]int64 `json:"ip" netstat:"Ip"`
-	ICMP    map[string]int64 `json:"icmp" netstat:"Icmp"`
-	ICMPMsg map[string]int64 `json:"icmp_msg" netstat:"IcmpMsg"`
-	TCP     map[string]int64 `json:"tcp" netstat:"Tcp"`
-	UDP     map[string]int64 `json:"udp" netstat:"Udp"`
-	UDPLite map[string]int64 `json:"udp_lite" netstat:"UdpLite"`
+	IP      map[string]uint64 `json:"ip" netstat:"Ip"`
+	ICMP    map[string]uint64 `json:"icmp" netstat:"Icmp"`
+	ICMPMsg map[string]uint64 `json:"icmp_msg" netstat:"IcmpMsg"`
+	TCP     map[string]uint64 `json:"tcp" netstat:"Tcp"`
+	UDP     map[string]uint64 `json:"udp" netstat:"Udp"`
+	UDPLite map[string]uint64 `json:"udp_lite" netstat:"UdpLite"`
 }
 
 // Netstat represents the data from /proc/net/netstat
 type Netstat struct {
-	TCPExt map[string]int64 `json:"tcp_ext" netstat:"TcpExt"`
-	IPExt  map[string]int64 `json:"ip_ext" netstat:"IpExt"`
+	TCPExt map[string]uint64 `json:"tcp_ext" netstat:"TcpExt"`
+	IPExt  map[string]uint64 `json:"ip_ext" netstat:"IpExt"`
 }
 
 // NetworkCountersInfo represents available network counters from /proc/net


### PR DESCRIPTION
So, in order to deal with the fact that `TCP.MaxConn` can be a `-1`, we originally stored `ProcNet` values in `map[string]int64`.

However, after talking with @urso and looking it over, chances are there's some `uint64` sized values floating around in here. Looking at the kernel source, it appears that `MaxConn` is the only signed value in here, and it's stored in a unsigned long before being cast to an int in order to print.


I'm not entirely happy with this, but we're in a situation where we have one oddball value that we want to handle differently. This PR just requires the user that there's a value they need to print as an `int` or hex value in order to make it usable. 

There's a few other solutions here:

Make a struct like this:
```
type SNMP struct {
	IP      map[string]uint64 `json:"ip" netstat:"Ip"`
	ICMP    map[string]uint64 `json:"icmp" netstat:"Icmp"`
	ICMPMsg map[string]uint64 `json:"icmp_msg" netstat:"IcmpMsg"`
	TCP     map[string]uint64 `json:"tcp" netstat:"Tcp"`
	UDP     map[string]uint64 `json:"udp" netstat:"Udp"`
	UDPLite map[string]uint64 `json:"udp_lite" netstat:"UdpLite"`
        TCPMaxConn int32 `json:"max_conn"`
}
```


Or like this:


```
type SNMP struct {
	IP      map[string]uint64 `json:"ip" netstat:"Ip"`
	ICMP    map[string]uint64 `json:"icmp" netstat:"Icmp"`
	ICMPMsg map[string]uint64 `json:"icmp_msg" netstat:"IcmpMsg"`
	TCP     SNMPTCP `json:"tcp" netstat:"Tcp"`
	UDP     map[string]uint64 `json:"udp" netstat:"Udp"`
	UDPLite map[string]uint64 `json:"udp_lite" netstat:"UdpLite"`
}

type SNMPTCP{
    MaxConn int32 
    Values map[string]uint64

}

```