### PR TITLE
Host: add `os.type` (OSInfo.Type) from ECS 1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added os.type field to host info. [#87](https://github.com/elastic/go-sysinfo/pull/87)
+
 ### Changed
 
 ### Deprecated

--- a/providers/aix/os_aix.go
+++ b/providers/aix/os_aix.go
@@ -46,6 +46,7 @@ func getOSInfo() (*types.OSInfo, error) {
 	build := strings.SplitN(string(procVersion), "\n", 4)[2]
 
 	return &types.OSInfo{
+		Type:     "unix",
 		Family:   "aix",
 		Platform: "aix",
 		Name:     "aix",

--- a/providers/darwin/os.go
+++ b/providers/darwin/os.go
@@ -81,6 +81,7 @@ func getOSInfo(data []byte) (*types.OSInfo, error) {
 	}
 
 	return &types.OSInfo{
+		Type:     "macos",
 		Family:   "darwin",
 		Platform: "darwin",
 		Name:     productName,

--- a/providers/darwin/os_test.go
+++ b/providers/darwin/os_test.go
@@ -47,6 +47,7 @@ func TestOperatingSystem(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	assert.Equal(t, "macos", osInfo.Type)
 	assert.Equal(t, "darwin", osInfo.Family)
 	assert.Equal(t, "darwin", osInfo.Platform)
 	assert.Equal(t, "Mac OS X", osInfo.Name)

--- a/providers/linux/os.go
+++ b/providers/linux/os.go
@@ -145,6 +145,7 @@ func parseOSRelease(content []byte) (*types.OSInfo, error) {
 
 func makeOSInfo(osRelease map[string]string) (*types.OSInfo, error) {
 	os := &types.OSInfo{
+		Type:     "linux",
 		Platform: osRelease["ID"],
 		Name:     osRelease["NAME"],
 		Version:  osRelease["VERSION"],
@@ -238,7 +239,10 @@ func parseDistribRelease(platform string, content []byte) (*types.OSInfo, error)
 	var (
 		line = string(bytes.TrimSpace(content))
 		keys = distribReleaseRegexp.SubexpNames()
-		os   = &types.OSInfo{Platform: platform}
+		os   = &types.OSInfo{
+			Type:     "linux",
+			Platform: platform,
+		}
 	)
 
 	for i, m := range distribReleaseRegexp.FindStringSubmatch(line) {

--- a/providers/linux/os_test.go
+++ b/providers/linux/os_test.go
@@ -34,6 +34,7 @@ func TestOperatingSystem(t *testing.T) {
 			t.Fatal(err)
 		}
 		assert.Equal(t, types.OSInfo{
+			Type:     "linux",
 			Family:   "redhat",
 			Platform: "amzn",
 			Name:     "Amazon Linux AMI",
@@ -50,6 +51,7 @@ func TestOperatingSystem(t *testing.T) {
 			t.Fatal(err)
 		}
 		assert.Equal(t, types.OSInfo{
+			Type:     "linux",
 			Family:   "redhat",
 			Platform: "centos",
 			Name:     "CentOS",
@@ -66,6 +68,7 @@ func TestOperatingSystem(t *testing.T) {
 			t.Fatal(err)
 		}
 		assert.Equal(t, types.OSInfo{
+			Type:     "linux",
 			Family:   "redhat",
 			Platform: "centos",
 			Name:     "CentOS Linux",
@@ -83,6 +86,7 @@ func TestOperatingSystem(t *testing.T) {
 			t.Fatal(err)
 		}
 		assert.Equal(t, types.OSInfo{
+			Type:     "linux",
 			Family:   "debian",
 			Platform: "debian",
 			Name:     "Debian GNU/Linux",
@@ -98,6 +102,7 @@ func TestOperatingSystem(t *testing.T) {
 			t.Fatal(err)
 		}
 		assert.Equal(t, types.OSInfo{
+			Type:     "linux",
 			Family:   "debian",
 			Platform: "raspbian",
 			Name:     "Raspbian GNU/Linux",
@@ -113,6 +118,7 @@ func TestOperatingSystem(t *testing.T) {
 			t.Fatal(err)
 		}
 		assert.Equal(t, types.OSInfo{
+			Type:     "linux",
 			Family:   "redhat",
 			Platform: "rhel",
 			Name:     "Red Hat Enterprise Linux Server",
@@ -129,6 +135,7 @@ func TestOperatingSystem(t *testing.T) {
 			t.Fatal(err)
 		}
 		assert.Equal(t, types.OSInfo{
+			Type:     "linux",
 			Family:   "debian",
 			Platform: "ubuntu",
 			Name:     "Ubuntu",
@@ -146,6 +153,7 @@ func TestOperatingSystem(t *testing.T) {
 			t.Fatal(err)
 		}
 		assert.Equal(t, types.OSInfo{
+			Type:     "linux",
 			Family:   "debian",
 			Platform: "ubuntu",
 			Name:     "Ubuntu",
@@ -163,6 +171,7 @@ func TestOperatingSystem(t *testing.T) {
 			t.Fatal(err)
 		}
 		assert.Equal(t, types.OSInfo{
+			Type:     "linux",
 			Family:   "redhat",
 			Platform: "fedora",
 			Name:     "Fedora",

--- a/providers/windows/os_windows.go
+++ b/providers/windows/os_windows.go
@@ -40,6 +40,7 @@ func OperatingSystem() (*types.OSInfo, error) {
 	defer k.Close()
 
 	osInfo := &types.OSInfo{
+		Type:     "windows",
 		Family:   "windows",
 		Platform: "windows",
 	}

--- a/types/host.go
+++ b/types/host.go
@@ -81,6 +81,7 @@ func (host HostInfo) Uptime() time.Duration {
 
 // OSInfo contains basic OS information
 type OSInfo struct {
+	Type     string `json:"type"`               // OS Type (one of linux, macos, unix, windows).
 	Family   string `json:"family"`             // OS Family (e.g. redhat, debian, freebsd, windows).
 	Platform string `json:"platform"`           // OS platform (e.g. centos, ubuntu, windows).
 	Name     string `json:"name"`               // OS Name (e.g. Mac OS X, CentOS).


### PR DESCRIPTION
Adds a Type field to OSInfo. Follows the [ECS rules](https://www.elastic.co/guide/en/ecs/1.8/ecs-os.html#field-os-type):

"Use the os.type field to categorize the operating system into one of the broad commercial families.

One of these following values should be used (lowercase):
 - linux
 - macos
 - unix
 - windows

If the OS you’re dealing with is not in the list, the field should not be populated."