### PR TITLE
Close changelog for 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Add darwin/arm64 support (Apple M1). [#91](https://github.com/elastic/go-sysinfo/pull/91)
-
 ### Added
 
 ### Changed
@@ -18,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+
+## [1.6.0] - 2021-02-09
+
+### Added
+
+- Add darwin/arm64 support (Apple M1). [#91](https://github.com/elastic/go-sysinfo/pull/91)
 
 ## [1.5.0] - 2021-01-14
 
@@ -96,7 +100,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Changed the host containerized check to reduce false positives. [#42](https://github.com/elastic/go-sysinfo/pull/42) [#43](https://github.com/elastic/go-sysinfo/pull/43)
 
-[Unreleased]: https://github.com/elastic/go-sysinfo/compare/v1.5.0...HEAD
+[Unreleased]: https://github.com/elastic/go-sysinfo/compare/v1.6.0...HEAD
+[1.6.0]: https://github.com/elastic/go-sysinfo/releases/tag/v1.6.0
 [1.5.0]: https://github.com/elastic/go-sysinfo/releases/tag/v1.5.0
 [1.4.0]: https://github.com/elastic/go-sysinfo/releases/tag/v1.4.0
 [1.3.0]: https://github.com/elastic/go-sysinfo/releases/tag/v1.3.0


### PR DESCRIPTION
We need to create the 1.6.0 changelog so we can release the MAC M1 updates.