### PR TITLE
Add per-process NetworkCounters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add per-process network stats [#96](https://github.com/elastic/go-sysinfo/pull/96)
+
 ### Changed
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -51,3 +51,4 @@ that are implemented.
 | `OpenHandleCounter`    |        | x     |         |           |
 | `Seccomp`              |        | x     |         |           |
 | `Capabilities`         |        | x     |         |           |
+| `NetworkCounters`      |        | x     |         |           |

--- a/providers/aix/boottime_aix.go
+++ b/providers/aix/boottime_aix.go
@@ -74,5 +74,4 @@ func bootTime(filename string) (time.Time, error) {
 	}
 
 	return time.Time{}, errors.Wrap(err, "failed to get host uptime: no utmp record")
-
 }

--- a/providers/aix/defs_aix.go
+++ b/providers/aix/defs_aix.go
@@ -28,14 +28,16 @@ import "C"
 
 type prcred C.prcred_t
 
-type pstatus C.pstatus_t
-type prTimestruc64 C.pr_timestruc64_t
-type prSigset C.pr_sigset_t
-type fltset C.fltset_t
-type lwpstatus C.lwpstatus_t
-type prSiginfo64 C.pr_siginfo64_t
-type prStack64 C.pr_stack64_t
-type prSigaction64 C.struct_pr_sigaction64
-type prgregset C.prgregset_t
-type prfpregset C.prfpregset_t
-type pfamily C.pfamily_t
+type (
+	pstatus       C.pstatus_t
+	prTimestruc64 C.pr_timestruc64_t
+	prSigset      C.pr_sigset_t
+	fltset        C.fltset_t
+	lwpstatus     C.lwpstatus_t
+	prSiginfo64   C.pr_siginfo64_t
+	prStack64     C.pr_stack64_t
+	prSigaction64 C.struct_pr_sigaction64
+	prgregset     C.prgregset_t
+	prfpregset    C.prfpregset_t
+	pfamily       C.pfamily_t
+)

--- a/providers/aix/kernel_aix.go
+++ b/providers/aix/kernel_aix.go
@@ -46,7 +46,6 @@ func getKernelVersion() (int, int, error) {
 		return 0, 0, errors.Wrap(err, "parsing kernel release")
 	}
 	return version, release, nil
-
 }
 
 // KernelVersion returns the version of AIX kernel

--- a/providers/aix/machineid_aix.go
+++ b/providers/aix/machineid_aix.go
@@ -21,6 +21,7 @@ package aix
 #include <sys/utsname.h>
 */
 import "C"
+
 import (
 	"github.com/pkg/errors"
 )

--- a/providers/aix/process_aix.go
+++ b/providers/aix/process_aix.go
@@ -187,7 +187,6 @@ func (p *process) Info() (types.ProcessInfo, error) {
 	p.info.CWD = strings.TrimSuffix(cwd, "/")
 
 	return *p.info, nil
-
 }
 
 // Environment returns the environment of a process.
@@ -243,7 +242,6 @@ func (p *process) User() (types.UserInfo, error) {
 		EGID: strconv.Itoa(int(prcred.Egid)),
 		SGID: strconv.Itoa(int(prcred.Sgid)),
 	}, nil
-
 }
 
 // Memory returns the current memory usage of a process.

--- a/providers/aix/ztypes_aix_ppc64.go
+++ b/providers/aix/ztypes_aix_ppc64.go
@@ -61,17 +61,21 @@ type pstatus struct {
 	X_pad           [8]uint64
 	Lwp             lwpstatus
 }
+
 type prTimestruc64 struct {
 	Sec    int64
 	Nsec   int32
 	X__pad uint32
 }
+
 type prSigset struct {
 	Set [4]uint64
 }
+
 type fltset struct {
 	Set [4]uint64
 }
+
 type lwpstatus struct {
 	Lwpid    uint64
 	Flags    uint32
@@ -98,6 +102,7 @@ type lwpstatus struct {
 	Fpreg    prfpregset
 	Family   pfamily
 }
+
 type prSiginfo64 struct {
 	Signo   int32
 	Errno   int32
@@ -112,18 +117,21 @@ type prSiginfo64 struct {
 	Value   [8]byte
 	X__pad  [4]uint32
 }
+
 type prStack64 struct {
 	Sp     uint64
 	Size   uint64
 	Flags  int32
 	X__pad [5]int32
 }
+
 type prSigaction64 struct {
 	Union  [8]byte
 	Mask   prSigset
 	Flags  int32
 	X__pad [5]int32
 }
+
 type prgregset struct {
 	X__iar    uint64
 	X__msr    uint64
@@ -136,9 +144,11 @@ type prgregset struct {
 	X__gpr    [32]uint64
 	X__pad1   [8]uint64
 }
+
 type prfpregset struct {
 	X__fpr [32]float64
 }
+
 type pfamily struct {
 	Extoff  uint64
 	Extsize uint64

--- a/providers/darwin/process_darwin_test.go
+++ b/providers/darwin/process_darwin_test.go
@@ -28,8 +28,10 @@ import (
 	"github.com/elastic/go-sysinfo/internal/registry"
 )
 
-var _ registry.HostProvider = darwinSystem{}
-var _ registry.ProcessProvider = darwinSystem{}
+var (
+	_ registry.HostProvider    = darwinSystem{}
+	_ registry.ProcessProvider = darwinSystem{}
+)
 
 func TestKernProcInfo(t *testing.T) {
 	var p process

--- a/providers/linux/process_linux.go
+++ b/providers/linux/process_linux.go
@@ -253,6 +253,29 @@ func (p *process) User() (types.UserInfo, error) {
 	return user, nil
 }
 
+// NetworkStats reports network stats for an individual PID.
+func (p *process) NetworkCounters() (*types.NetworkCountersInfo, error) {
+	snmpRaw, err := ioutil.ReadFile(p.path("net/snmp"))
+	if err != nil {
+		return nil, err
+	}
+	snmp, err := getNetSnmpStats(snmpRaw)
+	if err != nil {
+		return nil, err
+	}
+
+	netstatRaw, err := ioutil.ReadFile(p.path("net/netstat"))
+	if err != nil {
+		return nil, err
+	}
+	netstat, err := getNetstatStats(netstatRaw)
+	if err != nil {
+		return nil, err
+	}
+
+	return &types.NetworkCountersInfo{SNMP: snmp, Netstat: netstat}, nil
+}
+
 func ticksToDuration(ticks uint64) time.Duration {
 	seconds := float64(ticks) / float64(userHz) * float64(time.Second)
 	return time.Duration(int64(seconds))

--- a/providers/linux/process_linux_test.go
+++ b/providers/linux/process_linux_test.go
@@ -49,5 +49,4 @@ func TestProcessNetstat(t *testing.T) {
 	assert.NotEmpty(t, stats.SNMP.IP, "IP")
 	assert.NotEmpty(t, stats.SNMP.TCP, "TCP")
 	assert.NotEmpty(t, stats.SNMP.UDP, "UDP")
-
 }

--- a/providers/linux/process_linux_test.go
+++ b/providers/linux/process_linux_test.go
@@ -44,12 +44,10 @@ func TestProcessNetstat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NotEmpty(t, stats.Netstat.IPExt, "IPExt")
-	assert.NotEmpty(t, stats.Netstat.TCPExt, "TCPExt")
+
 	assert.NotEmpty(t, stats.SNMP.ICMP, "ICMP")
-	assert.NotEmpty(t, stats.SNMP.ICMPMsg, "ICMPMsg")
 	assert.NotEmpty(t, stats.SNMP.IP, "IP")
 	assert.NotEmpty(t, stats.SNMP.TCP, "TCP")
 	assert.NotEmpty(t, stats.SNMP.UDP, "UDP")
-	assert.NotEmpty(t, stats.SNMP.UDPLite, "UDPLite")
+
 }

--- a/providers/linux/process_linux_test.go
+++ b/providers/linux/process_linux_test.go
@@ -18,8 +18,35 @@
 package linux
 
 import (
+	"testing"
+
 	"github.com/elastic/go-sysinfo/internal/registry"
+	"github.com/elastic/go-sysinfo/types"
+	"github.com/stretchr/testify/assert"
 )
 
 var _ registry.HostProvider = linuxSystem{}
 var _ registry.ProcessProvider = linuxSystem{}
+
+func TestProcessNetstat(t *testing.T) {
+	proc, err := newLinuxSystem("").Self()
+	if err != nil {
+		t.Fatal(err)
+	}
+	procNetwork, ok := proc.(types.NetworkCounters)
+	if !ok {
+		t.Fatalf("error, cannot cast to types.NetworkCounters")
+	}
+	stats, err := procNetwork.NetworkCounters()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NotEmpty(t, stats.Netstat.IPExt, "IPExt")
+	assert.NotEmpty(t, stats.Netstat.TCPExt, "TCPExt")
+	assert.NotEmpty(t, stats.SNMP.ICMP, "ICMP")
+	assert.NotEmpty(t, stats.SNMP.ICMPMsg, "ICMPMsg")
+	assert.NotEmpty(t, stats.SNMP.IP, "IP")
+	assert.NotEmpty(t, stats.SNMP.TCP, "TCP")
+	assert.NotEmpty(t, stats.SNMP.UDP, "UDP")
+	assert.NotEmpty(t, stats.SNMP.UDPLite, "UDPLite")
+}

--- a/providers/linux/process_linux_test.go
+++ b/providers/linux/process_linux_test.go
@@ -20,9 +20,10 @@ package linux
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/go-sysinfo/internal/registry"
 	"github.com/elastic/go-sysinfo/types"
-	"github.com/stretchr/testify/assert"
 )
 
 var (

--- a/providers/linux/process_linux_test.go
+++ b/providers/linux/process_linux_test.go
@@ -25,8 +25,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var _ registry.HostProvider = linuxSystem{}
-var _ registry.ProcessProvider = linuxSystem{}
+var (
+	_ registry.HostProvider    = linuxSystem{}
+	_ registry.ProcessProvider = linuxSystem{}
+)
 
 func TestProcessNetstat(t *testing.T) {
 	proc, err := newLinuxSystem("").Self()

--- a/providers/windows/process_windows_test.go
+++ b/providers/windows/process_windows_test.go
@@ -21,5 +21,7 @@ import (
 	"github.com/elastic/go-sysinfo/internal/registry"
 )
 
-var _ registry.HostProvider = windowsSystem{}
-var _ registry.ProcessProvider = windowsSystem{}
+var (
+	_ registry.HostProvider    = windowsSystem{}
+	_ registry.ProcessProvider = windowsSystem{}
+)

--- a/system_test.go
+++ b/system_test.go
@@ -45,13 +45,13 @@ type ProcessFeatures struct {
 }
 
 var expectedProcessFeatures = map[string]*ProcessFeatures{
-	"darwin": &ProcessFeatures{
+	"darwin": {
 		ProcessInfo:          true,
 		Environment:          true,
 		OpenHandleEnumerator: false,
 		OpenHandleCounter:    false,
 	},
-	"linux": &ProcessFeatures{
+	"linux": {
 		ProcessInfo:          true,
 		Environment:          true,
 		OpenHandleEnumerator: true,
@@ -59,12 +59,12 @@ var expectedProcessFeatures = map[string]*ProcessFeatures{
 		Seccomp:              true,
 		Capabilities:         true,
 	},
-	"windows": &ProcessFeatures{
+	"windows": {
 		ProcessInfo:          true,
 		OpenHandleEnumerator: false,
 		OpenHandleCounter:    true,
 	},
-	"aix": &ProcessFeatures{
+	"aix": {
 		ProcessInfo:          true,
 		Environment:          true,
 		OpenHandleEnumerator: false,


### PR DESCRIPTION
This is a fairly simple PR that adds the ability to query per-process network stats, found under `/proc/[PID]/net/`.

This basically reuses the existing code that grabs these stats at a global level, since the only difference is the path. I've never tinkered with the process stats before, so hopefully I'm not forgetting anything.

I also took the liberty of running `make format` on everything, so there's a handful of added changes.