### PR TITLE
Require Go 1.17 for module

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,9 +6,8 @@ image: Visual Studio 2015
 # Environment variables
 environment:
   GOPATH: c:\gopath
-  GO111MODULE: on
-  GVM_GO_VERSION: 1.12.4
-  GVM_DL: https://github.com/andrewkroh/gvm/releases/download/v0.2.0/gvm-windows-amd64.exe
+  GVM_GO_VERSION: 1.17.10
+  GVM_DL: https://github.com/andrewkroh/gvm/releases/download/v0.4.1/gvm-windows-amd64.exe
 
 # Custom clone folder (variables are not expanded here).
 clone_folder: c:\gopath\src\github.com\elastic\go-sysinfo
@@ -32,7 +31,7 @@ install:
   - set PATH=%GOPATH%\bin;%PATH%
   - go version
   - go env
-  - cmd /C "set ""GO111MODULE=off"" && go get github.com/elastic/go-licenser"
+  - cmd /C go install github.com/elastic/go-licenser@latest"
   - python --version
 
 before_build:

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -9,7 +9,6 @@ pipeline {
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
     JOB_GIT_CREDENTIALS = "f6c7695a-671e-4f4f-a331-acdce44ff9ba"
     PIPELINE_LOG_LEVEL = 'INFO'
-    GO111MODULE = 'on'
   }
   options {
     timeout(time: 1, unit: 'HOURS')
@@ -38,7 +37,7 @@ pipeline {
         axes {
           axis {
             name 'GO_VERSION'
-            values '1.12.17', '1.16'
+            values '1.17.10', '1.18.2'
           }
           axis {
             name 'PLATFORM'
@@ -49,7 +48,7 @@ pipeline {
           exclude {
             axis {
               name 'GO_VERSION'
-              values '1.12.17'
+              values '1.17.10'
             }
             axis {
               name 'PLATFORM'
@@ -59,7 +58,7 @@ pipeline {
           exclude {
             axis {
               name 'GO_VERSION'
-              values '1.16'
+              values '1.18.2'
             }
             axis {
               name 'PLATFORM'

--- a/.ci/scripts/check_format.go
+++ b/.ci/scripts/check_format.go
@@ -41,9 +41,7 @@ func main() {
 		paths = flag.Args()
 	}
 
-	goGet := exec.Command("go", "get", "-u", "golang.org/x/tools/cmd/goimports")
-	goGet.Env = os.Environ()
-	goGet.Env = append(goGet.Env, "GO111MODULE=off")
+	goGet := exec.Command("go", "install", "golang.org/x/tools/cmd/goimports@latest")
 	out, err := goGet.Output()
 	if err != nil {
 		log.Fatalf("failed to %v: %v", strings.Join(goGet.Args, " "), err)

--- a/.ci/scripts/check_lint.go
+++ b/.ci/scripts/check_lint.go
@@ -40,9 +40,7 @@ func main() {
 	log.SetFlags(0)
 	flag.Parse()
 
-	goGet := exec.Command("go", "get", "-u", "golang.org/x/lint/golint")
-	goGet.Env = os.Environ()
-	goGet.Env = append(goGet.Env, "GO111MODULE=off")
+	goGet := exec.Command("go", "install", "golang.org/x/lint/golint@latest")
 	out, err := goGet.Output()
 	if err != nil {
 		log.Fatalf("failed to %v: %v", strings.Join(goGet.Args, " "), err)

--- a/.ci/scripts/test.bat
+++ b/.ci/scripts/test.bat
@@ -1,6 +1,4 @@
-SET GO111MODULE=off
-go get -u github.com/elastic/go-licenser
-SET GO111MODULE=on
+go install github.com/elastic/go-licenser@latest
 
 go mod verify
 go-licenser -d
@@ -11,5 +9,5 @@ mkdir -p build
 SET OUT_FILE=build\output-report.out
 go test "./..." -v > %OUT_FILE% | type %OUT_FILE%
 
-go get -v -u github.com/jstemmer/go-junit-report
+go install github.com/jstemmer/go-junit-report@latest
 go-junit-report > build\junit-%GO_VERSION%.xml < %OUT_FILE%

--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-GO111MODULE=off go get -u github.com/elastic/go-licenser
+go install github.com/elastic/go-licenser@latest
 
 go mod verify
 go-licenser -d
@@ -14,7 +14,7 @@ export OUT_FILE="build/test-report.out"
 mkdir -p build
 go test "./..." -v 2>&1 | tee ${OUT_FILE}
 status=$?
-go get -v -u github.com/jstemmer/go-junit-report
+go install github.com/jstemmer/go-junit-report@latest
 go-junit-report > "build/junit-${GO_VERSION}.xml" < ${OUT_FILE}
 
 exit ${status}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated module to require Go 1.17.
+
 ### Deprecated
 
 ### Removed

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ imports: $(GOPATH)/bin/goimports
 
 $(GOPATH)/bin/go-licenser:
 	@echo "go-licenser missing, installing"
-	GO111MODULE=off go get -u github.com/elastic/go-licenser
+	go install github.com/elastic/go-licenser@latest
 
 $(GOPATH)/bin/gofumpt:
 	@echo "gofumpt missing, installing"
@@ -26,4 +26,4 @@ $(GOPATH)/bin/gofumpt:
 
 $(GOPATH)/bin/goimports:
 	@echo "goimports missing, installing"
-	GO111MODULE=off go get -u golang.org/x/tools/cmd/goimports
+	go install golang.org/x/tools/cmd/goimports@latest

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/elastic/go-sysinfo
 
+go 1.17
+
 require (
 	github.com/elastic/go-windows v1.0.0
 	github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901
@@ -10,4 +12,7 @@ require (
 	howett.net/plist v0.0.0-20181124034731-591f970eefbb
 )
 
-go 1.13
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+)

--- a/providers/aix/boottime_test.go
+++ b/providers/aix/boottime_test.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build aix
 // +build aix
 
 package aix

--- a/providers/aix/defs_aix.go
+++ b/providers/aix/defs_aix.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build ignore
 // +build ignore
 
 package aix

--- a/providers/darwin/arch_darwin.go
+++ b/providers/darwin/arch_darwin.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build (amd64 && cgo) || (arm64 && cgo)
 // +build amd64,cgo arm64,cgo
 
 package darwin

--- a/providers/darwin/boottime_darwin.go
+++ b/providers/darwin/boottime_darwin.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build (amd64 && cgo) || (arm64 && cgo)
 // +build amd64,cgo arm64,cgo
 
 package darwin

--- a/providers/darwin/defs_darwin.go
+++ b/providers/darwin/defs_darwin.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build ignore
 // +build ignore
 
 package darwin

--- a/providers/darwin/host_darwin.go
+++ b/providers/darwin/host_darwin.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build (amd64 && cgo) || (arm64 && cgo)
 // +build amd64,cgo arm64,cgo
 
 package darwin

--- a/providers/darwin/kernel_darwin.go
+++ b/providers/darwin/kernel_darwin.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build !386
 // +build !386
 
 package darwin

--- a/providers/darwin/machineid_darwin.go
+++ b/providers/darwin/machineid_darwin.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build (amd64 && cgo) || (arm64 && cgo)
 // +build amd64,cgo arm64,cgo
 
 package darwin

--- a/providers/darwin/memory_darwin.go
+++ b/providers/darwin/memory_darwin.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build (amd64 && cgo) || (arm64 && cgo)
 // +build amd64,cgo arm64,cgo
 
 package darwin

--- a/providers/darwin/process_darwin.go
+++ b/providers/darwin/process_darwin.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build (amd64 && cgo) || (arm64 && cgo)
 // +build amd64,cgo arm64,cgo
 
 package darwin

--- a/providers/darwin/process_darwin_test.go
+++ b/providers/darwin/process_darwin_test.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build (amd64 && cgo) || (arm64 && cgo)
 // +build amd64,cgo arm64,cgo
 
 package darwin

--- a/providers/darwin/syscall_darwin.go
+++ b/providers/darwin/syscall_darwin.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build (amd64 && cgo) || (arm64 && cgo)
 // +build amd64,cgo arm64,cgo
 
 package darwin

--- a/providers/linux/os_test.go
+++ b/providers/linux/os_test.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build !windows
 // +build !windows
 
 package linux


### PR DESCRIPTION
Require Go 1.17 for the module and update all scripts to use the "go install pkg@version" format for any tool installs.