### PR TITLE
Add OS testdata from RHEL9

### DIFF
--- a/providers/linux/os_test.go
+++ b/providers/linux/os_test.go
@@ -148,6 +148,24 @@ func TestOperatingSystem(t *testing.T) {
 		}, *os)
 		t.Logf("%#v", os)
 	})
+	t.Run("redhat9", func(t *testing.T) {
+		// Data from 'docker pull redhat/ubi9:9.0.0-1468'.
+		os, err := getOSInfo("testdata/redhat9")
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, types.OSInfo{
+			Type:     "linux",
+			Family:   "redhat",
+			Platform: "rhel",
+			Name:     "Red Hat Enterprise Linux",
+			Version:  "9.0 (Plow)",
+			Major:    9,
+			Minor:    0,
+			Codename: "Plow",
+		}, *os)
+		t.Logf("%#v", os)
+	})
 	t.Run("ubuntu1404", func(t *testing.T) {
 		os, err := getOSInfo("testdata/ubuntu1404")
 		if err != nil {

--- a/providers/linux/testdata/redhat9/etc/os-release
+++ b/providers/linux/testdata/redhat9/etc/os-release
@@ -1,0 +1,1 @@
+../usr/lib/os-release

--- a/providers/linux/testdata/redhat9/etc/redhat-release
+++ b/providers/linux/testdata/redhat9/etc/redhat-release
@@ -1,0 +1,1 @@
+Red Hat Enterprise Linux release 9.0 (Plow)

--- a/providers/linux/testdata/redhat9/etc/system-release
+++ b/providers/linux/testdata/redhat9/etc/system-release
@@ -1,0 +1,1 @@
+redhat-release

--- a/providers/linux/testdata/redhat9/usr/lib/os-release
+++ b/providers/linux/testdata/redhat9/usr/lib/os-release
@@ -1,0 +1,18 @@
+NAME="Red Hat Enterprise Linux"
+VERSION="9.0 (Plow)"
+ID="rhel"
+ID_LIKE="fedora"
+VERSION_ID="9.0"
+PLATFORM_ID="platform:el9"
+PRETTY_NAME="Red Hat Enterprise Linux 9.0 (Plow)"
+ANSI_COLOR="0;31"
+LOGO="fedora-logo-icon"
+CPE_NAME="cpe:/o:redhat:enterprise_linux:9::baseos"
+HOME_URL="https://www.redhat.com/"
+DOCUMENTATION_URL="https://access.redhat.com/documentation/red_hat_enterprise_linux/9/"
+BUG_REPORT_URL="https://bugzilla.redhat.com/"
+
+REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 9"
+REDHAT_BUGZILLA_PRODUCT_VERSION=9.0
+REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
+REDHAT_SUPPORT_PRODUCT_VERSION="9.0"


### PR DESCRIPTION
RedHat 9 was released around May 10, 2022 so I wanted to add some
test data to ensure that the OS info collection is compatiable.
The test data was collected from 'docker pull redhat/ubi9:9.0.0-1468'.

This is the layout of the files:

```
[root@7508b75fea6c etc]# ls -la *release
lrwxrwxrwx 1 root root 22 Apr  6 15:03 os-release -> ..//usr/lib/os-release
-rw-r--r-- 1 root root 44 Apr  6 15:03 redhat-release
lrwxrwxrwx 1 root root 14 Apr  6 15:03 system-release -> redhat-release
```