### PR TITLE
Round boot time to nearest second on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated module to require Go 1.17. [#111](https://github.com/elastic/go-sysinfo/pull/111)
+- The boot time value for Windows is now rounded to the nearest second to provide a more stable value. [#53](https://github.com/elastic/go-sysinfo/issues/53) [#114](https://github.com/elastic/go-sysinfo/pull/114)
 
 ### Deprecated
 

--- a/providers/windows/boottime_windows_test.go
+++ b/providers/windows/boottime_windows_test.go
@@ -18,26 +18,16 @@
 package windows
 
 import (
-	"time"
+	"testing"
 
-	"github.com/pkg/errors"
-
-	windows "github.com/elastic/go-windows"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func BootTime() (time.Time, error) {
-	msSinceBoot, err := windows.GetTickCount64()
-	if err != nil {
-		return time.Time{}, errors.Wrap(err, "failed to get boot time")
-	}
+func TestBootTime(t *testing.T) {
+	bootTime, err := BootTime()
+	require.NoError(t, err)
 
-	bootTime := time.Now().Add(-1 * time.Duration(msSinceBoot) * time.Millisecond)
-
-	// According to GetTickCount64, the resolution of the value is limited to
-	// the resolution of the system timer, which is typically in the range of
-	// 10 milliseconds to 16 milliseconds. So this will round the value to the
-	// nearest second to not mislead anyone about the precision of the value
-	// and to provide a stable value.
-	bootTime = bootTime.Round(time.Second)
-	return bootTime, nil
+	// There should be no sub-second precision in the time.
+	assert.Equal(t, 0, bootTime.Nanosecond())
 }


### PR DESCRIPTION
The precision of the system timer is limited so round the value
to provide a more stable time value.

Fixes #53