### PR TITLE
refactor: replace GetTickCount64 with DurationSinceBoot from stdlib

### DIFF
--- a/providers/windows/boottime_windows.go
+++ b/providers/windows/boottime_windows.go
@@ -18,19 +18,13 @@
 package windows
 
 import (
-	"fmt"
 	"time"
 
-	windows "github.com/elastic/go-windows"
+	"golang.org/x/sys/windows"
 )
 
 func BootTime() (time.Time, error) {
-	msSinceBoot, err := windows.GetTickCount64()
-	if err != nil {
-		return time.Time{}, fmt.Errorf("failed to get boot time: %w", err)
-	}
-
-	bootTime := time.Now().Add(-1 * time.Duration(msSinceBoot) * time.Millisecond)
+	bootTime := time.Now().Add(-1 * windows.DurationSinceBoot())
 
 	// According to GetTickCount64, the resolution of the value is limited to
 	// the resolution of the system timer, which is typically in the range of


### PR DESCRIPTION
DurationSinceBoot was added to the stdlib.

See https://github.com/golang/sys/commit/5da285871e9c6a1c3acade75bea3282d33f55ebd