### PR TITLE
refactor: use go 1.17 run syntax in makefile tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,14 @@
-GOPATH?=~/go
-
 .phony: update
 update: fmt lic imports
 
 .PHONY: lic
-lic: $(GOPATH)/bin/go-licenser
-	go-licenser
+lic:
+	go run github.com/elastic/go-licenser@latest
 
 .PHONY: fmt
-fmt: $(GOPATH)/bin/gofumpt
-	gofumpt -w -l ./
+fmt:
+	go run mvdan.cc/gofumpt@latest -w -l ./
 
 .PHONY: imports
-imports: $(GOPATH)/bin/goimports
-	goimports -l -local github.com/elastic/go-sysinfo ./
-
-$(GOPATH)/bin/go-licenser:
-	@echo "go-licenser missing, installing"
-	go install github.com/elastic/go-licenser@latest
-
-$(GOPATH)/bin/gofumpt:
-	@echo "gofumpt missing, installing"
-	#Ugly boilerplate for go mod installs
-	cd $(mktemp -d); go mod init tmp; go get mvdan.cc/gofumpt
-
-$(GOPATH)/bin/goimports:
-	@echo "goimports missing, installing"
-	go install golang.org/x/tools/cmd/goimports@latest
+imports:
+	go run golang.org/x/tools/cmd/goimports@latest -l -local github.com/elastic/go-sysinfo ./

--- a/providers/linux/capabilities_linux.go
+++ b/providers/linux/capabilities_linux.go
@@ -26,8 +26,9 @@ import (
 // capabilityNames is mapping of capability constant values to names.
 //
 // Generated with:
-//   curl -s https://raw.githubusercontent.com/torvalds/linux/master/include/uapi/linux/capability.h | \
-//   grep -P '^#define CAP_\w+\s+\d+' | perl -pe 's/#define (\w+)\s+(\d+)/\2: "\1",/g'
+//
+//	curl -s https://raw.githubusercontent.com/torvalds/linux/master/include/uapi/linux/capability.h | \
+//	grep -P '^#define CAP_\w+\s+\d+' | perl -pe 's/#define (\w+)\s+(\d+)/\2: "\1",/g'
 var capabilityNames = map[int]string{
 	0:  "chown",
 	1:  "dac_override",


### PR DESCRIPTION
replace old workaround and go install with go run syntax. Formatting also took care of an issue introduced in go 1.19 with the style changes around documentation/comments.