### PR TITLE
feat: replace custom sysctl implementation with stdlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Remove custom sysctl implementation and partial cgo requirement 
+
 ### Deprecated
 
 ### Removed

--- a/providers/darwin/host_darwin.go
+++ b/providers/darwin/host_darwin.go
@@ -71,9 +71,12 @@ func (h *host) Memory() (*types.HostMemoryInfo, error) {
 	var mem types.HostMemoryInfo
 
 	// Total physical memory.
-	if err := sysctlByName("hw.memsize", &mem.Total); err != nil {
+	total, err := MemTotal()
+	if err != nil {
 		return nil, fmt.Errorf("failed to get total physical memory: %w", err)
 	}
+
+	mem.Total = total
 
 	// Page size for computing byte totals.
 	pageSizeBytes, err := getPageSize()

--- a/providers/darwin/process_darwin.go
+++ b/providers/darwin/process_darwin.go
@@ -218,9 +218,8 @@ var nullTerminator = []byte{0}
 // callbacks params are optional,
 // up to the caller as to which pieces of data they want
 func kern_procargs(pid int, p *process) error {
-	mib := []C.int{C.CTL_KERN, C.KERN_PROCARGS2, C.int(pid)}
 	var data []byte
-	if err := sysctl(mib, &data); err != nil {
+	if err := sysctl("kern.procargs2", &data, pid); err != nil {
 		return nil
 	}
 	buf := bytes.NewBuffer(data)

--- a/providers/darwin/process_darwin.go
+++ b/providers/darwin/process_darwin.go
@@ -35,8 +35,9 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/elastic/go-sysinfo/types"
 	"golang.org/x/sys/unix"
+
+	"github.com/elastic/go-sysinfo/types"
 )
 
 //go:generate sh -c "go tool cgo -godefs defs_darwin.go > ztypes_darwin.go"

--- a/providers/darwin/process_darwin.go
+++ b/providers/darwin/process_darwin.go
@@ -36,6 +36,7 @@ import (
 	"unsafe"
 
 	"github.com/elastic/go-sysinfo/types"
+	"golang.org/x/sys/unix"
 )
 
 //go:generate sh -c "go tool cgo -godefs defs_darwin.go > ztypes_darwin.go"
@@ -218,8 +219,8 @@ var nullTerminator = []byte{0}
 // callbacks params are optional,
 // up to the caller as to which pieces of data they want
 func kern_procargs(pid int, p *process) error {
-	var data []byte
-	if err := sysctl("kern.procargs2", &data, pid); err != nil {
+	data, err := unix.SysctlRaw("kern.procargs2", pid)
+	if err != nil {
 		return nil
 	}
 	buf := bytes.NewBuffer(data)

--- a/providers/darwin/syscall_darwin.go
+++ b/providers/darwin/syscall_darwin.go
@@ -33,116 +33,16 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"sync"
-	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/unix"
 )
 
-// Single-word zero for use when we need a valid pointer to 0 bytes.
-// See mksyscall.pl.
-var _zero uintptr
-
-// Buffer Pool
-
-var bufferPool = sync.Pool{
-	New: func() interface{} {
-		return &poolMem{
-			buf: make([]byte, argMax),
-		}
-	},
-}
-
-type poolMem struct {
-	buf  []byte
-	pool *sync.Pool
-}
-
-func getPoolMem() *poolMem {
-	pm := bufferPool.Get().(*poolMem)
-	pm.buf = pm.buf[0:cap(pm.buf)]
-	pm.pool = &bufferPool
-	return pm
-}
-
-func (m *poolMem) Release() { m.pool.Put(m) }
-
-// Common errors.
-
-// Do the interface allocations only once for common
-// Errno values.
-var (
-	errEAGAIN error = syscall.EAGAIN
-	errEINVAL error = syscall.EINVAL
-	errENOENT error = syscall.ENOENT
-)
-
-// errnoErr returns common boxed Errno values, to prevent
-// allocations at runtime.
-func errnoErr(e syscall.Errno) error {
-	switch e {
-	case 0:
-		return nil
-	case syscall.EAGAIN:
-		return errEAGAIN
-	case syscall.EINVAL:
-		return errEINVAL
-	case syscall.ENOENT:
-		return errENOENT
-	}
-	return e
-}
-
-func _sysctl(mib []C.int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
-	var _p0 unsafe.Pointer
-	if len(mib) > 0 {
-		_p0 = unsafe.Pointer(&mib[0])
-	} else {
-		_p0 = unsafe.Pointer(&_zero)
-	}
-	_, _, e1 := syscall.Syscall6(syscall.SYS___SYSCTL, uintptr(_p0), uintptr(len(mib)), uintptr(unsafe.Pointer(old)), uintptr(unsafe.Pointer(oldlen)), uintptr(unsafe.Pointer(new)), uintptr(newlen))
-	if e1 != 0 {
-		err = errnoErr(e1)
-	}
-	return
-}
-
-// Translate "kern.hostname" to []_C_int{0,1,2,3}.
-func nametomib(name string) (mib []C.int, err error) {
-	const siz = unsafe.Sizeof(mib[0])
-
-	// NOTE(rsc): It seems strange to set the buffer to have
-	// size CTL_MAXNAME+2 but use only CTL_MAXNAME
-	// as the size. I don't know why the +2 is here, but the
-	// kernel uses +2 for its own implementation of this function.
-	// I am scared that if we don't include the +2 here, the kernel
-	// will silently write 2 words farther than we specify
-	// and we'll get memory corruption.
-	var buf [C.CTL_MAXNAME + 2]C.int
-	n := uintptr(C.CTL_MAXNAME) * siz
-
-	p := (*byte)(unsafe.Pointer(&buf[0]))
-	bytes, err := syscall.ByteSliceFromString(name)
+func sysctl(name string, value interface{}, args ...int) error {
+	data, err := unix.SysctlRaw(name, args...)
 	if err != nil {
-		return nil, err
-	}
-
-	// Magic sysctl: "setting" 0.3 to a string name
-	// lets you read back the array of integers form.
-	if err = _sysctl([]C.int{0, 3}, p, &n, &bytes[0], uintptr(len(name))); err != nil {
-		return nil, err
-	}
-	return buf[0 : n/siz], nil
-}
-
-func sysctl(mib []C.int, value interface{}) error {
-	mem := getPoolMem()
-	defer mem.Release()
-
-	size := uintptr(len(mem.buf))
-	if err := _sysctl(mib, &mem.buf[0], &size, nil, 0); err != nil {
 		return err
 	}
-	data := mem.buf[0:size]
 
 	switch v := value.(type) {
 	case *[]byte:
@@ -156,12 +56,7 @@ func sysctl(mib []C.int, value interface{}) error {
 }
 
 func sysctlByName(name string, out interface{}) error {
-	mib, err := nametomib(name)
-	if err != nil {
-		return err
-	}
-
-	return sysctl(mib, out)
+	return sysctl(name, out)
 }
 
 type cpuUsage struct {

--- a/providers/darwin/syscall_darwin.go
+++ b/providers/darwin/syscall_darwin.go
@@ -106,7 +106,7 @@ const vmSwapUsageMIB = "vm.swapusage"
 
 func getSwapUsage() (*swapUsage, error) {
 	var swap swapUsage
-	data, err := unix.SysctlRaw(vmSwapUsageMIB);
+	data, err := unix.SysctlRaw(vmSwapUsageMIB)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Remove custom string->mib conversion code and sysctl implementation.
Reduce code complexity and cgo dependency

Related to https://github.com/elastic/apm-server/issues/8718