### PR TITLE
feat: implement darwin process list without cgo

### DIFF
--- a/providers/darwin/process_darwin_test.go
+++ b/providers/darwin/process_darwin_test.go
@@ -94,3 +94,26 @@ func TestProcessEnvironmentInternal(t *testing.T) {
 
 	assert.Equal(t, "FOO", p.env[fooValueEnvVar])
 }
+
+func TestProcesses(t *testing.T) {
+	var s darwinSystem
+	ps, err := s.Processes()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pinfo, err := ps[0].Info()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if pinfo.PID == 0 {
+		t.Fatal("empty pid")
+	}
+
+	if pinfo.Exe == "" {
+		t.Fatal("empty exec")
+	}
+
+	t.Log(ps[0].Info())
+}


### PR DESCRIPTION
Implement process list retrieval without cgo.

Add a test to verify the fields are populated and there is no error.

Related to https://github.com/elastic/apm-server/issues/8718
