### PR TITLE
feat: add stubs for noncgo systems to increase compatibility

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -43,6 +43,10 @@ pipeline {
             name 'PLATFORM'
             values 'ubuntu-18 && immutable', 'windows-2019 && immutable', 'orka && darwin && x86_64', 'orka && darwin && arm64'
           }
+          axis {
+            name 'CGO_ENABLED'
+            values '0', '1'
+          }
         }
         excludes {
           exclude {
@@ -68,6 +72,9 @@ pipeline {
         }
         stages {
           stage('Test') {
+	    environment {
+	      CGO_ENABLED = "${env.CGO_ENABLED}"
+            }
             options { skipDefaultCheckout() }
             agent { label "${PLATFORM}" }
             steps {

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ This table lists the OS and architectures for which a "provider" is implemented.
 | GOOS / GOARCH  | Requires CGO | Tested |
 |----------------|--------------|--------|
 | aix/ppc64      | x            |        |
-| darwin/amd64   | x            | x      |
-| darwin/arm64   | x            | x      |
+| darwin/amd64   | optional *   | x      |
+| darwin/arm64   | optional *   | x      |
 | linux/386      |              |        |
 | linux/amd64    |              | x      |
 | linux/arm      |              |        |
@@ -76,3 +76,5 @@ This table lists the OS and architectures for which a "provider" is implemented.
 | windows/amd64  |              | x      |
 | windows/arm64  |              |        |
 | windows/arm    |              |        |
+
+* On darwin (macOS) host information like machineid and process information like memory, cpu, user and starttime require cgo.

--- a/providers/darwin/host_darwin.go
+++ b/providers/darwin/host_darwin.go
@@ -15,8 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build (amd64 && cgo) || (arm64 && cgo)
-// +build amd64,cgo arm64,cgo
+//go:build amd64 || arm64
+// +build amd64 arm64
 
 package darwin
 

--- a/providers/darwin/machineid_nocgo_darwin.go
+++ b/providers/darwin/machineid_nocgo_darwin.go
@@ -19,8 +19,12 @@
 
 package darwin
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/elastic/go-sysinfo/types"
+)
 
 func MachineID() (string, error) {
-	return "", fmt.Errorf("machineid without cgo not implemented")
+	return "", fmt.Errorf("machineid requires cgo: %w", types.ErrNotImplemented)
 }

--- a/providers/darwin/machineid_nocgo_darwin.go
+++ b/providers/darwin/machineid_nocgo_darwin.go
@@ -1,0 +1,26 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build (amd64 && !cgo) || (arm64 && !cgo)
+
+package darwin
+
+import "fmt"
+
+func MachineID() (string, error) {
+	return "", fmt.Errorf("machineid without cgo not implemented")
+}

--- a/providers/darwin/process_cgo_darwin.go
+++ b/providers/darwin/process_cgo_darwin.go
@@ -1,0 +1,59 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build (amd64 && cgo) || (arm64 && cgo)
+// +build amd64,cgo arm64,cgo
+
+package darwin
+
+// #cgo LDFLAGS:-lproc
+// #include <sys/sysctl.h>
+// #include <libproc.h>
+import "C"
+
+import (
+	"errors"
+	"unsafe"
+)
+
+//go:generate sh -c "go tool cgo -godefs defs_darwin.go > ztypes_darwin.go"
+
+func getProcTaskAllInfo(pid int, info *procTaskAllInfo) error {
+	size := C.int(unsafe.Sizeof(*info))
+	ptr := unsafe.Pointer(info)
+
+	n, err := C.proc_pidinfo(C.int(pid), C.PROC_PIDTASKALLINFO, 0, ptr, size)
+	if err != nil {
+		return err
+	} else if n != size {
+		return errors.New("failed to read process info with proc_pidinfo")
+	}
+
+	return nil
+}
+
+func getProcVnodePathInfo(pid int, info *procVnodePathInfo) error {
+	size := C.int(unsafe.Sizeof(*info))
+	ptr := unsafe.Pointer(info)
+
+	n := C.proc_pidinfo(C.int(pid), C.PROC_PIDVNODEPATHINFO, 0, ptr, size)
+	if n != size {
+		return errors.New("failed to read vnode info with proc_pidinfo")
+	}
+
+	return nil
+}

--- a/providers/darwin/process_darwin.go
+++ b/providers/darwin/process_darwin.go
@@ -90,12 +90,12 @@ func (p *process) Info() (types.ProcessInfo, error) {
 	}
 
 	var task procTaskAllInfo
-	if err := getProcTaskAllInfo(p.pid, &task); err != nil {
+	if err := getProcTaskAllInfo(p.pid, &task); err != nil && err != types.ErrNotImplemented {
 		return types.ProcessInfo{}, err
 	}
 
 	var vnode procVnodePathInfo
-	if err := getProcVnodePathInfo(p.pid, &vnode); err != nil {
+	if err := getProcVnodePathInfo(p.pid, &vnode); err != nil && err != types.ErrNotImplemented {
 		return types.ProcessInfo{}, err
 	}
 

--- a/providers/darwin/process_darwin.go
+++ b/providers/darwin/process_darwin.go
@@ -15,32 +15,23 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build (amd64 && cgo) || (arm64 && cgo)
-// +build amd64,cgo arm64,cgo
+//go:build amd64 || arm64
+// +build amd64 arm64
 
 package darwin
-
-// #cgo LDFLAGS:-lproc
-// #include <sys/sysctl.h>
-// #include <libproc.h>
-import "C"
 
 import (
 	"bytes"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"os"
 	"strconv"
 	"time"
-	"unsafe"
 
 	"golang.org/x/sys/unix"
 
 	"github.com/elastic/go-sysinfo/types"
 )
-
-//go:generate sh -c "go tool cgo -godefs defs_darwin.go > ztypes_darwin.go"
 
 func (s darwinSystem) Processes() ([]types.Process, error) {
 	ps, err := unix.SysctlKinfoProcSlice("kern.proc.all")
@@ -170,32 +161,6 @@ func (p *process) Memory() (types.MemoryInfo, error) {
 			"page_faults": uint64(task.Ptinfo.Faults),
 		},
 	}, nil
-}
-
-func getProcTaskAllInfo(pid int, info *procTaskAllInfo) error {
-	size := C.int(unsafe.Sizeof(*info))
-	ptr := unsafe.Pointer(info)
-
-	n, err := C.proc_pidinfo(C.int(pid), C.PROC_PIDTASKALLINFO, 0, ptr, size)
-	if err != nil {
-		return err
-	} else if n != size {
-		return errors.New("failed to read process info with proc_pidinfo")
-	}
-
-	return nil
-}
-
-func getProcVnodePathInfo(pid int, info *procVnodePathInfo) error {
-	size := C.int(unsafe.Sizeof(*info))
-	ptr := unsafe.Pointer(info)
-
-	n := C.proc_pidinfo(C.int(pid), C.PROC_PIDVNODEPATHINFO, 0, ptr, size)
-	if n != size {
-		return errors.New("failed to read vnode info with proc_pidinfo")
-	}
-
-	return nil
 }
 
 var nullTerminator = []byte{0}

--- a/providers/darwin/process_darwin_test.go
+++ b/providers/darwin/process_darwin_test.go
@@ -15,8 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build (amd64 && cgo) || (arm64 && cgo)
-// +build amd64,cgo arm64,cgo
+//go:build amd64 || arm64
+// +build amd64 arm64
 
 package darwin
 

--- a/providers/darwin/process_nocgo_darwin.go
+++ b/providers/darwin/process_nocgo_darwin.go
@@ -1,0 +1,28 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build (amd64 && !cgo) || (arm64 && !cgo)
+
+package darwin
+
+func getProcTaskAllInfo(pid int, info *procTaskAllInfo) error {
+	return nil
+}
+
+func getProcVnodePathInfo(pid int, info *procVnodePathInfo) error {
+	return nil
+}

--- a/providers/darwin/process_nocgo_darwin.go
+++ b/providers/darwin/process_nocgo_darwin.go
@@ -19,10 +19,12 @@
 
 package darwin
 
+import "github.com/elastic/go-sysinfo/types"
+
 func getProcTaskAllInfo(pid int, info *procTaskAllInfo) error {
-	return nil
+	return types.ErrNotImplemented
 }
 
 func getProcVnodePathInfo(pid int, info *procVnodePathInfo) error {
-	return nil
+	return types.ErrNotImplemented
 }

--- a/providers/darwin/syscall_cgo_darwin.go
+++ b/providers/darwin/syscall_cgo_darwin.go
@@ -1,0 +1,72 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build (amd64 && cgo) || (arm64 && cgo)
+// +build amd64,cgo arm64,cgo
+
+package darwin
+
+/*
+#cgo LDFLAGS:-lproc
+#include <sys/sysctl.h>
+#include <mach/mach_time.h>
+#include <mach/mach_host.h>
+#include <unistd.h>
+*/
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+func getHostCPULoadInfo() (*cpuUsage, error) {
+	var count C.mach_msg_type_number_t = C.HOST_CPU_LOAD_INFO_COUNT
+	var cpu cpuUsage
+	status := C.host_statistics(C.host_t(C.mach_host_self()),
+		C.HOST_CPU_LOAD_INFO,
+		C.host_info_t(unsafe.Pointer(&cpu)),
+		&count)
+
+	if status != C.KERN_SUCCESS {
+		return nil, fmt.Errorf("host_statistics returned status %d", status)
+	}
+
+	return &cpu, nil
+}
+
+// getClockTicks returns the number of click ticks in one jiffie.
+func getClockTicks() int {
+	return int(C.sysconf(C._SC_CLK_TCK))
+}
+
+func getHostVMInfo64() (*vmStatistics64Data, error) {
+	var count C.mach_msg_type_number_t = C.HOST_VM_INFO64_COUNT
+
+	var vmStat vmStatistics64Data
+	status := C.host_statistics64(
+		C.host_t(C.mach_host_self()),
+		C.HOST_VM_INFO64,
+		C.host_info_t(unsafe.Pointer(&vmStat)),
+		&count)
+
+	if status != C.KERN_SUCCESS {
+		return nil, fmt.Errorf("host_statistics64 returned status %d", status)
+	}
+
+	return &vmStat, nil
+}

--- a/providers/darwin/syscall_darwin.go
+++ b/providers/darwin/syscall_darwin.go
@@ -15,25 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build (amd64 && cgo) || (arm64 && cgo)
-// +build amd64,cgo arm64,cgo
+//go:build amd64 || arm64
+// +build amd64 arm64
 
 package darwin
-
-/*
-#cgo LDFLAGS:-lproc
-#include <sys/sysctl.h>
-#include <mach/mach_time.h>
-#include <mach/mach_host.h>
-#include <unistd.h>
-*/
-import "C"
 
 import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"unsafe"
 
 	"golang.org/x/sys/unix"
 )
@@ -43,43 +33,6 @@ type cpuUsage struct {
 	System uint32
 	Idle   uint32
 	Nice   uint32
-}
-
-func getHostCPULoadInfo() (*cpuUsage, error) {
-	var count C.mach_msg_type_number_t = C.HOST_CPU_LOAD_INFO_COUNT
-	var cpu cpuUsage
-	status := C.host_statistics(C.host_t(C.mach_host_self()),
-		C.HOST_CPU_LOAD_INFO,
-		C.host_info_t(unsafe.Pointer(&cpu)),
-		&count)
-
-	if status != C.KERN_SUCCESS {
-		return nil, fmt.Errorf("host_statistics returned status %d", status)
-	}
-
-	return &cpu, nil
-}
-
-// getClockTicks returns the number of click ticks in one jiffie.
-func getClockTicks() int {
-	return int(C.sysconf(C._SC_CLK_TCK))
-}
-
-func getHostVMInfo64() (*vmStatistics64Data, error) {
-	var count C.mach_msg_type_number_t = C.HOST_VM_INFO64_COUNT
-
-	var vmStat vmStatistics64Data
-	status := C.host_statistics64(
-		C.host_t(C.mach_host_self()),
-		C.HOST_VM_INFO64,
-		C.host_info_t(unsafe.Pointer(&vmStat)),
-		&count)
-
-	if status != C.KERN_SUCCESS {
-		return nil, fmt.Errorf("host_statistics64 returned status %d", status)
-	}
-
-	return &vmStat, nil
 }
 
 func getPageSize() (uint64, error) {

--- a/providers/darwin/syscall_nocgo_darwin.go
+++ b/providers/darwin/syscall_nocgo_darwin.go
@@ -19,10 +19,14 @@
 
 package darwin
 
-import "errors"
+import (
+	"fmt"
+
+	"github.com/elastic/go-sysinfo/types"
+)
 
 func getHostCPULoadInfo() (*cpuUsage, error) {
-	return nil, errors.New("host cpu load without cgo not implemented")
+	return nil, fmt.Errorf("host cpu load requires cgo: %w", types.ErrNotImplemented)
 }
 
 // getClockTicks returns the number of click ticks in one jiffie.
@@ -31,5 +35,5 @@ func getClockTicks() int {
 }
 
 func getHostVMInfo64() (*vmStatistics64Data, error) {
-	return nil, errors.New("host vm info without cgo not implemented")
+	return nil, fmt.Errorf("host vm info requires cgo: %w", types.ErrNotImplemented)
 }

--- a/providers/darwin/syscall_nocgo_darwin.go
+++ b/providers/darwin/syscall_nocgo_darwin.go
@@ -1,0 +1,35 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build (amd64 && !cgo) || (arm64 && !cgo)
+
+package darwin
+
+import "errors"
+
+func getHostCPULoadInfo() (*cpuUsage, error) {
+	return nil, errors.New("host cpu load without cgo not implemented")
+}
+
+// getClockTicks returns the number of click ticks in one jiffie.
+func getClockTicks() int {
+	return 0
+}
+
+func getHostVMInfo64() (*vmStatistics64Data, error) {
+	return nil, errors.New("host vm info without cgo not implemented")
+}

--- a/system.go
+++ b/system.go
@@ -43,6 +43,7 @@ func Go() types.GoInfo {
 // Host returns information about host on which this process is running. If
 // host information collection is not implemented for this platform then
 // types.ErrNotImplemented is returned.
+// On Darwin (macOS) a types.ErrNotImplemented is returned with cgo disabled.
 func Host() (types.Host, error) {
 	provider := registry.GetHostProvider()
 	if provider == nil {

--- a/types/host.go
+++ b/types/host.go
@@ -20,6 +20,8 @@ package types
 import "time"
 
 // Host is the interface that wraps methods for returning Host stats
+// It may return partial information if the provider
+// implementation is unable to collect all of the necessary data.
 type Host interface {
 	CPUTimer
 	Info() HostInfo

--- a/types/process.go
+++ b/types/process.go
@@ -22,8 +22,9 @@ import "time"
 // Process is the main wrapper for gathering information on a process
 type Process interface {
 	CPUTimer
-	// On Darwin (macOS) this method returns partial information
-	// with cgo disabled.
+	// Info returns process info.
+	// It may return partial information if the provider
+	// implementation is unable to collect all of the necessary data.
 	Info() (ProcessInfo, error)
 	Memory() (MemoryInfo, error)
 	User() (UserInfo, error)
@@ -101,8 +102,8 @@ type CPUTimer interface {
 	// The User and System fields are guaranteed
 	// to be populated for all platforms, and
 	// for both hosts and processes.
-	// On Darwin (macOS) this returns types.ErrNotImplemented
-	// with cgo disabled.
+	// This may return types.ErrNotImplemented
+	// if the provider cannot implement collection of this data.
 	CPUTime() (CPUTimes, error)
 }
 

--- a/types/process.go
+++ b/types/process.go
@@ -22,6 +22,8 @@ import "time"
 // Process is the main wrapper for gathering information on a process
 type Process interface {
 	CPUTimer
+	// On Darwin (macOS) this method returns partial information
+	// with cgo disabled.
 	Info() (ProcessInfo, error)
 	Memory() (MemoryInfo, error)
 	User() (UserInfo, error)
@@ -99,6 +101,8 @@ type CPUTimer interface {
 	// The User and System fields are guaranteed
 	// to be populated for all platforms, and
 	// for both hosts and processes.
+	// On Darwin (macOS) this returns types.ErrNotImplemented
+	// with cgo disabled.
 	CPUTime() (CPUTimes, error)
 }
 


### PR DESCRIPTION
Allow to compile and use go-sysinfo for noncgo systems. If a feature needs cgo, an error is returned without compromising the noncgo features.

Related to https://github.com/elastic/apm-server/issues/8718

This should allow for the java attacher to work in APM server