### PR TITLE
feat: implement process user without cgo

### DIFF
--- a/providers/darwin/process_darwin_test.go
+++ b/providers/darwin/process_darwin_test.go
@@ -115,7 +115,7 @@ func TestProcesses(t *testing.T) {
 		t.Fatal("empty exec")
 	}
 
-	u, err :=  ps[0].User()
+	u, err := ps[0].User()
 	require.NoError(t, err)
 
 	require.NotEmpty(t, u.UID)

--- a/providers/darwin/process_darwin_test.go
+++ b/providers/darwin/process_darwin_test.go
@@ -115,5 +115,15 @@ func TestProcesses(t *testing.T) {
 		t.Fatal("empty exec")
 	}
 
+	u, err :=  ps[0].User()
+	require.NoError(t, err)
+
+	require.NotEmpty(t, u.UID)
+	require.NotEmpty(t, u.EUID)
+	require.NotEmpty(t, u.SUID)
+	require.NotEmpty(t, u.GID)
+	require.NotEmpty(t, u.EGID)
+	require.NotEmpty(t, u.SGID)
+
 	t.Log(ps[0].Info())
 }


### PR DESCRIPTION
While bumping the library in the apm-server I noticed we need the process user for certain features.

Implement process user info retrieval without cgo. This should be the last blocker for the apm-server.

Replace old `getProcTaskAllInfo` call (requires cgo) with sysctl based call that retrieves data from the kproc_info struct.

Add assertions to make sure the fields are not empty.

Related to https://github.com/elastic/go-sysinfo/issues/127
Related to https://github.com/elastic/apm-server/issues/8718