### PR TITLE
providers/darwin/process: fix error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- On darwin without CGO `process.Info()` could fail, but would not return the error. [#150](https://github.com/elastic/go-sysinfo/pull/150)
+
 ## [1.9.0]
 
 ### Added


### PR DESCRIPTION
kern_procargs was not returning an error when kern.procargs2 failed. Then meant that you didn't get an error when the process no longer exists or when you didn't have permissions to access the process.

For process.Info(), this especially affected builds running without CGO enabled. When running with CGO there are other calls that will fail with "no such process" or "operation not permitted" before we get to calling kern.procargs2, but without CGO it goes directly to calling kern.procargs2. This resulted in Info() returning a zero value types.ProcessInfo and no error.

Fixes #148