### PR TITLE
use go-junit-report/v2 for reporting junit

### DIFF
--- a/.ci/scripts/test.bat
+++ b/.ci/scripts/test.bat
@@ -9,5 +9,5 @@ mkdir -p build
 SET OUT_FILE=build\output-report.out
 go test "./..." -v > %OUT_FILE% | type %OUT_FILE%
 
-go install github.com/jstemmer/go-junit-report@latest
+go install github.com/jstemmer/go-junit-report/v2@latest
 go-junit-report > build\junit-%GO_VERSION%.xml < %OUT_FILE%

--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -39,7 +39,7 @@ export OUT_FILE="build/test-report.out"
 mkdir -p build
 go test "./..." -v 2>&1 | tee ${OUT_FILE}
 status=$?
-go install github.com/jstemmer/go-junit-report@latest
+go install github.com/jstemmer/go-junit-report/v2@latest
 go-junit-report > "build/junit-${GO_VERSION}.xml" < ${OUT_FILE}
 
 exit ${status}


### PR DESCRIPTION
Use https://github.com/jstemmer/go-junit-report/releases/tag/v2.0.0

### Why

Visualise the `output`

<img width="1356" alt="image" src="https://user-images.githubusercontent.com/2871786/215047540-074e1e17-9046-47aa-8d9f-18c19d4fc82a.png">

as that's not the case when using `v1`

<img width="1143" alt="image" src="https://user-images.githubusercontent.com/2871786/215047617-911a7425-ac25-451a-963a-6624359d7497.png">



