### PR TITLE
Adding convenience method for FQDN-aware hostname

### DIFF
--- a/providers/darwin/host_darwin.go
+++ b/providers/darwin/host_darwin.go
@@ -222,6 +222,7 @@ func (r *reader) fqdn(h *host) {
 
 	h.info.FQDN = v
 }
+
 func (r *reader) network(h *host) {
 	ips, macs, err := shared.Network()
 	if r.addErr(err) {

--- a/providers/linux/host_fqdn_integration_linux_test.go
+++ b/providers/linux/host_fqdn_integration_linux_test.go
@@ -32,9 +32,11 @@ import (
 	"github.com/docker/docker/pkg/stdcopy"
 )
 
-const wantHostname = "hostname"
-const wantDomain = "some.domain"
-const wantFQDN = wantHostname + "." + wantDomain
+const (
+	wantHostname = "hostname"
+	wantDomain   = "some.domain"
+	wantFQDN     = wantHostname + "." + wantDomain
+)
 
 func TestHost_FQDN(t *testing.T) {
 	const envKey = "GO_VERSION"
@@ -62,7 +64,8 @@ func TestHost_FQDN(t *testing.T) {
 					"go", "test", "-v",
 					"-tags", "integration,docker",
 					"-run", "^TestHost_FQDN_set$",
-					"./providers/linux"},
+					"./providers/linux",
+				},
 				Tty: false,
 			},
 		},
@@ -78,7 +81,8 @@ func TestHost_FQDN(t *testing.T) {
 					"go", "test", "-v",
 					"-tags", "integration,docker",
 					"-run", "^TestHost_FQDN_set$",
-					"./providers/linux"},
+					"./providers/linux",
+				},
 				Tty: false,
 			},
 		},
@@ -93,7 +97,8 @@ func TestHost_FQDN(t *testing.T) {
 					"go", "test", "-v", "-count", "1",
 					"-tags", "integration,docker",
 					"-run", "^TestHost_FQDN_not_set$",
-					"./providers/linux"},
+					"./providers/linux",
+				},
 				Tty: false,
 			},
 		},
@@ -137,7 +142,8 @@ func runOnDocker(t *testing.T, cli *client.Client, cf *container.Config) {
 	}
 	defer func() {
 		err = cli.ContainerRemove(ctx, resp.ID, types.ContainerRemoveOptions{
-			Force: true, RemoveVolumes: true})
+			Force: true, RemoveVolumes: true,
+		})
 		if err != nil {
 			t.Logf("WARNING: could not remove docker container: %v", err)
 		}

--- a/providers/linux/os.go
+++ b/providers/linux/os.go
@@ -50,8 +50,10 @@ var (
 
 // familyMap contains a mapping of family -> []platforms.
 var familyMap = map[string][]string{
-	"redhat": {"redhat", "fedora", "centos", "scientific", "oraclelinux", "ol",
-		"amzn", "rhel", "almalinux", "openeuler", "rocky"},
+	"redhat": {
+		"redhat", "fedora", "centos", "scientific", "oraclelinux", "ol",
+		"amzn", "rhel", "almalinux", "openeuler", "rocky",
+	},
 	"debian": {"debian", "ubuntu", "raspbian", "linuxmint"},
 	"suse":   {"suse", "sles", "opensuse", "opensuse-leap", "opensuse-tumbleweed"},
 }

--- a/types/host.go
+++ b/types/host.go
@@ -82,6 +82,16 @@ func (host HostInfo) Uptime() time.Duration {
 	return time.Since(host.BootTime)
 }
 
+// FQDNAwareHostname returns the system hostname, honoring the given
+// flag to report the FQDN or not.
+func (host HostInfo) FQDNAwareHostname(wantFQDN bool) string {
+	if wantFQDN {
+		return host.FQDN
+	}
+
+	return host.Hostname
+}
+
 // OSInfo contains basic OS information
 type OSInfo struct {
 	Type     string `json:"type"`               // OS Type (one of linux, macos, unix, windows).

--- a/types/host_test.go
+++ b/types/host_test.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package types
 
 import (

--- a/types/host_test.go
+++ b/types/host_test.go
@@ -18,17 +18,18 @@
 package types
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestHostInfo_FQDNAwareHostname(t *testing.T) {
 	hostInfo := HostInfo{
 		Hostname: "foo",
-		FQDN: "foo.bar.baz",
+		FQDN:     "foo.bar.baz",
 	}
 
-	tests := map[string]struct{
+	tests := map[string]struct {
 		wantFQDN bool
 		expected string
 	}{

--- a/types/host_test.go
+++ b/types/host_test.go
@@ -1,0 +1,34 @@
+package types
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestHostInfo_FQDNAwareHostname(t *testing.T) {
+	hostInfo := HostInfo{
+		Hostname: "foo",
+		FQDN: "foo.bar.baz",
+	}
+
+	tests := map[string]struct{
+		wantFQDN bool
+		expected string
+	}{
+		"want_fqdn": {
+			wantFQDN: true,
+			expected: "foo.bar.baz",
+		},
+		"no_fqdn": {
+			wantFQDN: false,
+			expected: "foo",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual := hostInfo.FQDNAwareHostname(test.wantFQDN)
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a convenience methods to the `HostInfo` struct, reporting the FQDN-aware hostname.