### PR TITLE
Make FQDN lookup function more testable

### DIFF
--- a/providers/shared/fqdn.go
+++ b/providers/shared/fqdn.go
@@ -32,6 +32,10 @@ func FQDN() (string, error) {
 		return "", fmt.Errorf("could not get hostname to look for FQDN: %w", err)
 	}
 
+	return fqdn(hostname)
+}
+
+func fqdn(hostname string) (string, error) {
 	var errs error
 	cname, err := net.LookupCNAME(hostname)
 	if err != nil {

--- a/providers/shared/fqdn_test.go
+++ b/providers/shared/fqdn_test.go
@@ -19,8 +19,9 @@ package shared
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestFQDN(t *testing.T) {

--- a/providers/shared/fqdn_test.go
+++ b/providers/shared/fqdn_test.go
@@ -68,8 +68,8 @@ func TestFQDN(t *testing.T) {
 func makeErrorRegex(osHostname string) string {
 	return fmt.Sprintf(
 		"could not get FQDN, all methods failed: "+
-			"failed looking up CNAME: lookup %s.*: no such host: "+
-			"failed looking up IP: lookup %s.*: no such host",
+			"failed looking up CNAME: lookup %s.*: "+
+			"failed looking up IP: lookup %s.*",
 		osHostname,
 		osHostname,
 	)

--- a/providers/shared/fqdn_test.go
+++ b/providers/shared/fqdn_test.go
@@ -30,6 +30,10 @@ func TestFQDN(t *testing.T) {
 		expectedFQDN string
 		expectedErr  error
 	}{
+		// This test case depends on network, particularly DNS,
+		// being available.  If it starts to fail often enough
+		// due to occasional network/DNS unavailability, we should
+		// probably just delete this test case.
 		"long_real_hostname": {
 			osHostname:   "elastic.co",
 			expectedFQDN: "elastic.co",

--- a/providers/shared/fqdn_test.go
+++ b/providers/shared/fqdn_test.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build linux || darwin
+
 package shared
 
 import (

--- a/providers/shared/fqdn_test.go
+++ b/providers/shared/fqdn_test.go
@@ -1,0 +1,71 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package shared
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestFQDN(t *testing.T) {
+	tests := map[string]struct {
+		osHostname   string
+		expectedFQDN string
+		expectedErr  error
+	}{
+		"long_real_hostname": {
+			osHostname:   "elastic.co",
+			expectedFQDN: "elastic.co",
+			expectedErr:  nil,
+		},
+		"long_nonexistent_hostname": {
+			osHostname:   "foo.bar.elastic.co",
+			expectedFQDN: "",
+			expectedErr:  makeError("foo.bar.elastic.co"),
+		},
+		"short_nonexistent_hostname": {
+			osHostname:   "foobarbaz",
+			expectedFQDN: "",
+			expectedErr:  makeError("foobarbaz"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			actualFQDN, err := fqdn(test.osHostname)
+			require.Equal(t, test.expectedFQDN, actualFQDN)
+
+			if test.expectedErr == nil {
+				require.Nil(t, err)
+			} else {
+				require.Equal(t, test.expectedErr.Error(), err.Error())
+			}
+		})
+	}
+}
+
+func makeError(osHostname string) error {
+	return fmt.Errorf(
+		"could not get FQDN, all methods failed: "+
+			"failed looking up CNAME: lookup %s: no such host: "+
+			"failed looking up IP: lookup %s: no such host",
+		osHostname,
+		osHostname,
+	)
+}


### PR DESCRIPTION
This PR refactors the `shared.FQDN()` function, extracting the lookup algorithm into a helper function, to make the code a bit more testable.  Having done that, the PR also adds a unit test for the helper function.