### PR TITLE
Return FQDN and error via `FQDN()` method on `Host` interface

### DIFF
--- a/providers/darwin/host_darwin.go
+++ b/providers/darwin/host_darwin.go
@@ -139,6 +139,10 @@ func (h *host) Memory() (*types.HostMemoryInfo, error) {
 	return &mem, nil
 }
 
+func (h *host) FQDN() (string, error) {
+	return shared.FQDN()
+}
+
 func (h *host) LoadAverage() (*types.LoadAverageInfo, error) {
 	load, err := getLoadAverage()
 	if err != nil {
@@ -160,7 +164,6 @@ func newHost() (*host, error) {
 	r.architecture(h)
 	r.bootTime(h)
 	r.hostname(h)
-	r.fqdn(h)
 	r.network(h)
 	r.kernelVersion(h)
 	r.os(h)
@@ -214,20 +217,6 @@ func (r *reader) hostname(h *host) {
 	h.info.Hostname = v
 }
 
-func (r *reader) fqdn(h *host) {
-	v, err := shared.FQDN()
-
-	// We record any FQDN lookup errors differently from errors in other
-	// lookup methods. FQDN lookup is "best effort" and we want consumers
-	// of the FQDN to decide how severely they want to treat the lookup
-	// errors.
-	if err != nil {
-		h.info.FQDNError = err
-		return
-	}
-
-	h.info.FQDN = v
-}
 func (r *reader) network(h *host) {
 	ips, macs, err := shared.Network()
 	if r.addErr(err) {

--- a/providers/darwin/host_darwin.go
+++ b/providers/darwin/host_darwin.go
@@ -216,7 +216,13 @@ func (r *reader) hostname(h *host) {
 
 func (r *reader) fqdn(h *host) {
 	v, err := shared.FQDN()
-	if r.addErr(err) {
+
+	// We record any FQDN lookup errors differently from errors in other
+	// lookup methods. FQDN lookup is "best effort" and we want consumers
+	// of the FQDN to decide how severely they want to treat the lookup
+	// errors.
+	if err != nil {
+		h.info.FQDNError = err
 		return
 	}
 

--- a/providers/linux/host_fqdn_integration_docker_linux_test.go
+++ b/providers/linux/host_fqdn_integration_docker_linux_test.go
@@ -22,6 +22,8 @@ package linux
 import (
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestHost_FQDN_set(t *testing.T) {
@@ -30,7 +32,8 @@ func TestHost_FQDN_set(t *testing.T) {
 		t.Fatal(fmt.Errorf("could not get host information: %w", err))
 	}
 
-	gotFQDN := host.FQDN()
+	gotFQDN, err := host.FQDN()
+	require.NoError(t, err)
 	if gotFQDN != wantFQDN {
 		t.Errorf("got FQDN %q, want: %q", gotFQDN, wantFQDN)
 	}
@@ -42,7 +45,8 @@ func TestHost_FQDN_not_set(t *testing.T) {
 		t.Fatal(fmt.Errorf("could not get host information: %w", err))
 	}
 
-	gotFQDN := host.FQDN()
+	gotFQDN, err := host.FQDN()
+	require.NoError(t, err)
 	hostname := host.Info().Hostname
 	if gotFQDN != hostname {
 		t.Errorf("name and FQDN should be the same but hostname: %s, FQDN %s", hostname, gotFQDN)

--- a/providers/linux/host_fqdn_integration_docker_linux_test.go
+++ b/providers/linux/host_fqdn_integration_docker_linux_test.go
@@ -30,9 +30,9 @@ func TestHost_FQDN_set(t *testing.T) {
 		t.Fatal(fmt.Errorf("could not get host information: %w", err))
 	}
 
-	got := host.Info()
-	if got.FQDN != wantFQDN {
-		t.Errorf("got FQDN %q, want: %q", got.FQDN, wantFQDN)
+	gotFQDN := host.FQDN()
+	if gotFQDN != wantFQDN {
+		t.Errorf("got FQDN %q, want: %q", gotFQDN, wantFQDN)
 	}
 }
 
@@ -42,8 +42,9 @@ func TestHost_FQDN_not_set(t *testing.T) {
 		t.Fatal(fmt.Errorf("could not get host information: %w", err))
 	}
 
-	got := host.Info()
-	if got.Hostname != got.FQDN {
-		t.Errorf("name and FQDN should be the same but hostname: %s, FQDN %s", got.Hostname, got.FQDN)
+	gotFQDN := host.FQDN()
+	hostname := host.Info().Hostname
+	if gotFQDN != hostname {
+		t.Errorf("name and FQDN should be the same but hostname: %s, FQDN %s", hostname, gotFQDN)
 	}
 }

--- a/providers/linux/host_linux.go
+++ b/providers/linux/host_linux.go
@@ -214,7 +214,13 @@ func (r *reader) hostname(h *host) {
 
 func (r *reader) fqdn(h *host) {
 	v, err := shared.FQDN()
-	if r.addErr(err) {
+
+	// We record any FQDN lookup errors differently from errors in other
+	// lookup methods. FQDN lookup is "best effort" and we want consumers
+	// of the FQDN to decide how severely they want to treat the lookup
+	// errors.
+	if err != nil {
+		h.info.FQDNError = err
 		return
 	}
 

--- a/providers/linux/host_linux.go
+++ b/providers/linux/host_linux.go
@@ -72,6 +72,10 @@ func (h *host) Memory() (*types.HostMemoryInfo, error) {
 	return parseMemInfo(content)
 }
 
+func (h *host) FQDN() (string, error) {
+	return shared.FQDN()
+}
+
 // VMStat reports data from /proc/vmstat on linux.
 func (h *host) VMStat() (*types.VMStatInfo, error) {
 	content, err := ioutil.ReadFile(h.procFS.path("vmstat"))
@@ -149,7 +153,6 @@ func newHost(fs procFS) (*host, error) {
 	r.bootTime(h)
 	r.containerized(h)
 	r.hostname(h)
-	r.fqdn(h)
 	r.network(h)
 	r.kernelVersion(h)
 	r.os(h)
@@ -210,21 +213,6 @@ func (r *reader) hostname(h *host) {
 		return
 	}
 	h.info.Hostname = v
-}
-
-func (r *reader) fqdn(h *host) {
-	v, err := shared.FQDN()
-
-	// We record any FQDN lookup errors differently from errors in other
-	// lookup methods. FQDN lookup is "best effort" and we want consumers
-	// of the FQDN to decide how severely they want to treat the lookup
-	// errors.
-	if err != nil {
-		h.info.FQDNError = err
-		return
-	}
-
-	h.info.FQDN = v
 }
 
 func (r *reader) network(h *host) {

--- a/providers/shared/fqdn.go
+++ b/providers/shared/fqdn.go
@@ -26,6 +26,20 @@ import (
 	"strings"
 )
 
+// FQDN attempts to lookup the host's fully-qualified domain name and returns it.
+// It does so using the following algorithm:
+//
+//  1. It gets the hostname from the OS. If this step fails, it returns an error.
+//
+//  2. It tries to perform a CNAME DNS lookup for the hostname. If this succeeds, it
+//     returns the CNAME (after trimming any trailing period) as the FQDN.
+//
+//  3. It tries to perform an IP lookup for the hostname. If this succeeds, it tries
+//     to perform a reverse DNS lookup on the returned IPs and returns the first
+//     successful result (after trimming any trailing period) as the FQDN.
+//
+//  4. If steps 2 and 3 both fail, an empty string is returned as the FQDN along with
+//     errors from those steps.
 func FQDN() (string, error) {
 	hostname, err := os.Hostname()
 	if err != nil {

--- a/providers/windows/host_windows.go
+++ b/providers/windows/host_windows.go
@@ -84,13 +84,21 @@ func (h *host) Memory() (*types.HostMemoryInfo, error) {
 	}, nil
 }
 
+func (h *host) FQDN() (string, error) {
+	fqdn, err := getComputerNameEx(stdwindows.ComputerNamePhysicalDnsFullyQualified)
+	if err != nil {
+		return "", fmt.Errorf("could not get windows FQDN: %s", err)
+	}
+
+	return strings.TrimSuffix(fqdn, ".")
+}
+
 func newHost() (*host, error) {
 	h := &host{}
 	r := &reader{}
 	r.architecture(h)
 	r.bootTime(h)
 	r.hostname(h)
-	r.fqdn(h)
 	r.network(h)
 	r.kernelVersion(h)
 	r.os(h)
@@ -142,17 +150,6 @@ func (r *reader) hostname(h *host) {
 		return
 	}
 	h.info.Hostname = v
-}
-
-func (r *reader) fqdn(h *host) {
-	fqdn, err := getComputerNameEx(
-		stdwindows.ComputerNamePhysicalDnsFullyQualified)
-	if err != nil {
-		r.addErr(fmt.Errorf("could not get windows FQDN: %s", err))
-		return
-	}
-
-	h.info.FQDN = strings.TrimSuffix(fqdn, ".")
 }
 
 func getComputerNameEx(name uint32) (string, error) {

--- a/providers/windows/host_windows.go
+++ b/providers/windows/host_windows.go
@@ -90,7 +90,7 @@ func (h *host) FQDN() (string, error) {
 		return "", fmt.Errorf("could not get windows FQDN: %s", err)
 	}
 
-	return strings.TrimSuffix(fqdn, ".")
+	return strings.TrimSuffix(fqdn, "."), nil
 }
 
 func newHost() (*host, error) {

--- a/types/host.go
+++ b/types/host.go
@@ -75,6 +75,12 @@ type HostInfo struct {
 	Timezone          string    `json:"timezone"`            // System timezone.
 	TimezoneOffsetSec int       `json:"timezone_offset_sec"` // Timezone offset (seconds from UTC).
 	UniqueID          string    `json:"id,omitempty"`        // Unique ID of the host (optional).
+
+	// FQDNError contains any errors that were encountered while looking up the FQDN for the host.
+	// FQDN lookup is "best effort". As such, we do want to capture any errors during the lookup, but
+	// separately from other errors, so users of the FQDN can treat any lookup errors less severely
+	// (or not) than errors looking up other host information, as it makes sense for their use case.
+	FQDNError error
 }
 
 // Uptime returns the system uptime

--- a/types/host.go
+++ b/types/host.go
@@ -26,6 +26,7 @@ type Host interface {
 	CPUTimer
 	Info() HostInfo
 	Memory() (*HostMemoryInfo, error)
+	FQDN() (string, error)
 }
 
 // NetworkCounters represents network stats from /proc/net

--- a/types/host.go
+++ b/types/host.go
@@ -68,20 +68,13 @@ type HostInfo struct {
 	BootTime          time.Time `json:"boot_time"`               // Host boot time.
 	Containerized     *bool     `json:"containerized,omitempty"` // Is the process containerized.
 	Hostname          string    `json:"name"`                    // Hostname
-	FQDN              string    `json:"fqdn"`
-	IPs               []string  `json:"ip,omitempty"`        // List of all IPs.
-	KernelVersion     string    `json:"kernel_version"`      // Kernel version.
-	MACs              []string  `json:"mac"`                 // List of MAC addresses.
-	OS                *OSInfo   `json:"os"`                  // OS information.
-	Timezone          string    `json:"timezone"`            // System timezone.
-	TimezoneOffsetSec int       `json:"timezone_offset_sec"` // Timezone offset (seconds from UTC).
-	UniqueID          string    `json:"id,omitempty"`        // Unique ID of the host (optional).
-
-	// FQDNError contains any errors that were encountered while looking up the FQDN for the host.
-	// FQDN lookup is "best effort". As such, we do want to capture any errors during the lookup, but
-	// separately from other errors, so users of the FQDN can treat any lookup errors less severely
-	// (or not) than errors looking up other host information, as it makes sense for their use case.
-	FQDNError error
+	IPs               []string  `json:"ip,omitempty"`            // List of all IPs.
+	KernelVersion     string    `json:"kernel_version"`          // Kernel version.
+	MACs              []string  `json:"mac"`                     // List of MAC addresses.
+	OS                *OSInfo   `json:"os"`                      // OS information.
+	Timezone          string    `json:"timezone"`                // System timezone.
+	TimezoneOffsetSec int       `json:"timezone_offset_sec"`     // Timezone offset (seconds from UTC).
+	UniqueID          string    `json:"id,omitempty"`            // Unique ID of the host (optional).
 }
 
 // Uptime returns the system uptime


### PR DESCRIPTION
This PR adds a new method to the `Host` interface: `FQDN() (string, error)`.  It removes the `FQDN` field on the `HostInfo` struct.

This change allows consumers of the `go-sysinfo` library to query the FQDN and any resulting errors during FQDN lookup.  Consumers can then choose to handle any errors with the severity they desire.