### PR TITLE
Update docker/docker

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/elastic/go-sysinfo
 go 1.18
 
 require (
-	github.com/docker/docker v20.10.24+incompatible
 	github.com/elastic/go-windows v1.0.0
 	github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901
+	github.com/moby/moby v23.0.3+incompatible
 	github.com/prometheus/procfs v0.8.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sys v0.5.0
@@ -16,6 +16,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/distribution v2.8.1+incompatible // indirect
+	github.com/docker/docker v23.0.3+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
@@ -25,7 +26,6 @@ require (
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/sirupsen/logrus v1.9.0 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/time v0.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/elastic/go-sysinfo
 go 1.18
 
 require (
+	github.com/docker/docker v23.0.3+incompatible
 	github.com/elastic/go-windows v1.0.0
 	github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901
-	github.com/moby/moby v23.0.3+incompatible
 	github.com/prometheus/procfs v0.8.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sys v0.5.0
@@ -16,7 +16,6 @@ require (
 	github.com/Microsoft/go-winio v0.6.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/distribution v2.8.1+incompatible // indirect
-	github.com/docker/docker v23.0.3+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
 github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v20.10.24+incompatible h1:Ugvxm7a8+Gz6vqQYQQ2W7GYq5EUPaAiuPgIfVyI3dYE=
-github.com/docker/docker v20.10.24+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v23.0.3+incompatible h1:9GhVsShNWz1hO//9BNg/dpMnZW25KydO4wtVxWAIbho=
+github.com/docker/docker v23.0.3+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
@@ -28,6 +28,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/moby/moby v23.0.3+incompatible h1:g+qvdrXfskgMXiq6DQMo5EdEIp8mo/9befVIddWstGI=
+github.com/moby/moby v23.0.3+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=
 github.com/moby/term v0.0.0-20221205130635-1aeaba878587 h1:HfkjXDfhgVaN5rmueG8cL8KKeFNecRCXFhaJ2qZ5SKA=
 github.com/moby/term v0.0.0-20221205130635-1aeaba878587/go.mod h1:8FzsFHVUBGZdbDsJw/ot+X+d5HLUbvklYLJ9uGfcI3Y=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
@@ -43,8 +45,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
-github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
-github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
@@ -71,7 +71,6 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,6 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/moby/moby v23.0.3+incompatible h1:g+qvdrXfskgMXiq6DQMo5EdEIp8mo/9befVIddWstGI=
-github.com/moby/moby v23.0.3+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=
 github.com/moby/term v0.0.0-20221205130635-1aeaba878587 h1:HfkjXDfhgVaN5rmueG8cL8KKeFNecRCXFhaJ2qZ5SKA=
 github.com/moby/term v0.0.0-20221205130635-1aeaba878587/go.mod h1:8FzsFHVUBGZdbDsJw/ot+X+d5HLUbvklYLJ9uGfcI3Y=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=

--- a/providers/linux/host_fqdn_integration_linux_test.go
+++ b/providers/linux/host_fqdn_integration_linux_test.go
@@ -26,15 +26,17 @@ import (
 	"os"
 	"testing"
 
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/client"
-	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/moby/moby/api/types"
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/client"
+	"github.com/moby/moby/pkg/stdcopy"
 )
 
-const wantHostname = "hostname"
-const wantDomain = "some.domain"
-const wantFQDN = wantHostname + "." + wantDomain
+const (
+	wantHostname = "hostname"
+	wantDomain   = "some.domain"
+	wantFQDN     = wantHostname + "." + wantDomain
+)
 
 func TestHost_FQDN(t *testing.T) {
 	const envKey = "GO_VERSION"
@@ -62,7 +64,8 @@ func TestHost_FQDN(t *testing.T) {
 					"go", "test", "-v",
 					"-tags", "integration,docker",
 					"-run", "^TestHost_FQDN_set$",
-					"./providers/linux"},
+					"./providers/linux",
+				},
 				Tty: false,
 			},
 		},
@@ -78,7 +81,8 @@ func TestHost_FQDN(t *testing.T) {
 					"go", "test", "-v",
 					"-tags", "integration,docker",
 					"-run", "^TestHost_FQDN_set$",
-					"./providers/linux"},
+					"./providers/linux",
+				},
 				Tty: false,
 			},
 		},
@@ -93,7 +97,8 @@ func TestHost_FQDN(t *testing.T) {
 					"go", "test", "-v", "-count", "1",
 					"-tags", "integration,docker",
 					"-run", "^TestHost_FQDN_not_set$",
-					"./providers/linux"},
+					"./providers/linux",
+				},
 				Tty: false,
 			},
 		},
@@ -137,7 +142,8 @@ func runOnDocker(t *testing.T, cli *client.Client, cf *container.Config) {
 	}
 	defer func() {
 		err = cli.ContainerRemove(ctx, resp.ID, types.ContainerRemoveOptions{
-			Force: true, RemoveVolumes: true})
+			Force: true, RemoveVolumes: true,
+		})
 		if err != nil {
 			t.Logf("WARNING: could not remove docker container: %v", err)
 		}

--- a/providers/linux/host_fqdn_integration_linux_test.go
+++ b/providers/linux/host_fqdn_integration_linux_test.go
@@ -26,10 +26,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/moby/moby/api/types"
-	"github.com/moby/moby/api/types/container"
-	"github.com/moby/moby/client"
-	"github.com/moby/moby/pkg/stdcopy"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/stdcopy"
 )
 
 const (

--- a/providers/linux/os.go
+++ b/providers/linux/os.go
@@ -50,8 +50,10 @@ var (
 
 // familyMap contains a mapping of family -> []platforms.
 var familyMap = map[string][]string{
-	"redhat": {"redhat", "fedora", "centos", "scientific", "oraclelinux", "ol",
-		"amzn", "rhel", "almalinux", "openeuler", "rocky"},
+	"redhat": {
+		"redhat", "fedora", "centos", "scientific", "oraclelinux", "ol",
+		"amzn", "rhel", "almalinux", "openeuler", "rocky",
+	},
 	"debian": {"debian", "ubuntu", "raspbian", "linuxmint"},
 	"suse":   {"suse", "sles", "opensuse", "opensuse-leap", "opensuse-tumbleweed"},
 }


### PR DESCRIPTION
snyk scanner for fleet-server has an issue with the `docker/docker` import being used: https://github.com/elastic/fleet-server/pull/2483

Update the dependency to new version.
Don't update to `moby/moby` as the upstream repo still uses the `docker` namespace