### PR TITLE
Cleanup: Remove `// +build` lines

### DIFF
--- a/providers/aix/boottime_aix_ppc64.go
+++ b/providers/aix/boottime_aix_ppc64.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build aix && ppc64
-// +build aix,ppc64
 
 package aix
 

--- a/providers/aix/boottime_aix_ppc64_test.go
+++ b/providers/aix/boottime_aix_ppc64_test.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build aix && ppc64
-// +build aix,ppc64
 
 package aix
 

--- a/providers/aix/defs_aix.go
+++ b/providers/aix/defs_aix.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build ignore
-// +build ignore
 
 package aix
 

--- a/providers/aix/host_aix_ppc64.go
+++ b/providers/aix/host_aix_ppc64.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build aix && ppc64 && cgo
-// +build aix,ppc64,cgo
 
 package aix
 

--- a/providers/aix/kernel_aix_ppc64.go
+++ b/providers/aix/kernel_aix_ppc64.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build aix && ppc64 && cgo
-// +build aix,ppc64,cgo
 
 package aix
 

--- a/providers/aix/machineid_aix_ppc64.go
+++ b/providers/aix/machineid_aix_ppc64.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build aix && ppc64 && cgo
-// +build aix,ppc64,cgo
 
 package aix
 

--- a/providers/aix/os_aix_ppc64.go
+++ b/providers/aix/os_aix_ppc64.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build aix && ppc64 && cgo
-// +build aix,ppc64,cgo
 
 package aix
 

--- a/providers/aix/process_aix_ppc64.go
+++ b/providers/aix/process_aix_ppc64.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build aix && ppc64 && cgo
-// +build aix,ppc64,cgo
 
 package aix
 

--- a/providers/aix/ztypes_aix_ppc64.go
+++ b/providers/aix/ztypes_aix_ppc64.go
@@ -19,7 +19,6 @@
 // cgo -godefs defs_aix.go
 
 //go:build aix && ppc64
-// +build aix,ppc64
 
 package aix
 

--- a/providers/darwin/arch_darwin.go
+++ b/providers/darwin/arch_darwin.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package darwin
 

--- a/providers/darwin/boottime_darwin.go
+++ b/providers/darwin/boottime_darwin.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package darwin
 

--- a/providers/darwin/defs_darwin.go
+++ b/providers/darwin/defs_darwin.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build ignore
-// +build ignore
 
 package darwin
 

--- a/providers/darwin/host_darwin.go
+++ b/providers/darwin/host_darwin.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package darwin
 

--- a/providers/darwin/kernel_darwin.go
+++ b/providers/darwin/kernel_darwin.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build !386
-// +build !386
 
 package darwin
 

--- a/providers/darwin/load_average_darwin.go
+++ b/providers/darwin/load_average_darwin.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package darwin
 

--- a/providers/darwin/machineid_darwin.go
+++ b/providers/darwin/machineid_darwin.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build (amd64 && cgo) || (arm64 && cgo)
-// +build amd64,cgo arm64,cgo
 
 package darwin
 

--- a/providers/darwin/memory_darwin.go
+++ b/providers/darwin/memory_darwin.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package darwin
 

--- a/providers/darwin/process_cgo_darwin.go
+++ b/providers/darwin/process_cgo_darwin.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build (amd64 && cgo) || (arm64 && cgo)
-// +build amd64,cgo arm64,cgo
 
 package darwin
 

--- a/providers/darwin/process_darwin.go
+++ b/providers/darwin/process_darwin.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package darwin
 

--- a/providers/darwin/process_darwin_test.go
+++ b/providers/darwin/process_darwin_test.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package darwin
 

--- a/providers/darwin/syscall_cgo_darwin.go
+++ b/providers/darwin/syscall_cgo_darwin.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build (amd64 && cgo) || (arm64 && cgo)
-// +build amd64,cgo arm64,cgo
 
 package darwin
 

--- a/providers/darwin/syscall_darwin.go
+++ b/providers/darwin/syscall_darwin.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package darwin
 

--- a/providers/linux/os_test.go
+++ b/providers/linux/os_test.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build !windows
-// +build !windows
 
 package linux
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR runs `go fix -fix buildtag ./...` on the `go-sysinfo` codebase to remove the deprecated `// +build` build tags from `.go` source files.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

Starting with Go 1.17, `//go:build` tags are preferred over the more bespoke `// +build` tags, for consistency with other `//go:` directives.  Starting with Go 1.18, `go fix` is able to remove the deprecated `// +build` tags and only leave the corresponding `//go:build` tags in their place.

More here: https://go.dev/doc/go1.18#go-build-lines

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
