### PR TITLE
providers/darwin - kern.procargs2 guard against runtime panic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,6 @@
 _obj
 
 *TEST.out
-main.retry
-testing/ssh_config
-testing/ve
 
 build/
+**/testdata/fuzz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Prevent possible runtime panic while reading process arguments on darwin. [#172](https://github.com/elastic/go-sysinfo/pull/172)
+
 ## [1.10.1]
 
 ### Added

--- a/providers/darwin/process_darwin.go
+++ b/providers/darwin/process_darwin.go
@@ -225,13 +225,8 @@ func parseKernProcargs2(data []byte, p *process) error {
 			break
 		}
 
-		parts := strings.SplitN(l, "=", 2)
-		key := parts[0]
-		var value string
-		if len(parts) == 2 {
-			value = parts[1]
-		}
-		env[key] = value
+		key, val, _ := strings.Cut(l, "=")
+		env[key] = val
 	}
 	p.env = env
 

--- a/providers/darwin/process_darwin.go
+++ b/providers/darwin/process_darwin.go
@@ -186,6 +186,11 @@ func kern_procargs(pid int, p *process) error {
 		}
 		return err
 	}
+
+	return parseKernProcargs2(data, p)
+}
+
+func parseKernProcargs2(data []byte, p *process) error {
 	buf := bytes.NewBuffer(data)
 
 	// argc
@@ -209,7 +214,7 @@ func kern_procargs(pid int, p *process) error {
 	}
 
 	// args
-	for i := 0; i < int(argc); i++ {
+	for len(lines) > 0 && len(p.args) < int(argc) {
 		p.args = append(p.args, string(lines[0]))
 		lines = lines[1:]
 	}

--- a/providers/darwin/process_darwin_test.go
+++ b/providers/darwin/process_darwin_test.go
@@ -155,12 +155,13 @@ func TestParseKernProcargs2(t *testing.T) {
 		{data: []byte{0, 0, 0, 0}, process: process{env: map[string]string{}}},
 		{data: []byte{5, 0, 0, 0}, process: process{env: map[string]string{}}},
 		{
-			data: buildKernProcargs2Data(3, "./example", []string{"/Users/test/example", "--one", "--two"}, []string{"TZ=UTC"}),
+			data: buildKernProcargs2Data(3, "./example", []string{"/Users/test/example", "--one", "--two"}, []string{"TZ=UTC", "FOO="}),
 			process: process{
 				exe:  "./example",
 				args: []string{"/Users/test/example", "--one", "--two"},
 				env: map[string]string{
-					"TZ": "UTC",
+					"TZ":  "UTC",
+					"FOO": "",
 				},
 			},
 		},


### PR DESCRIPTION
Prior to this change kern_procargs iterated over the data based
on the argc value without checking if the underlying slice held
enough args.

To prevent a runtime error this adds a check to verify there is more
data before trying to index another argument.

Add a fuzz test to check for panics in the parsing code for kern.procargs2.

Relates #173