### PR TITLE
Fix major and minor version parsing on older Windows

### DIFF
--- a/.changelog/175.txt
+++ b/.changelog/175.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+windows: On versions earlier than 10/2016, the `os.major` version was getting overwritten with
+what would have been the minor version, and the `os.minor` version was not being set.
+```

--- a/providers/windows/os_windows.go
+++ b/providers/windows/os_windows.go
@@ -68,7 +68,7 @@ func OperatingSystem() (*types.OSInfo, error) {
 			case 0:
 				osInfo.Major, _ = strconv.Atoi(p)
 			case 1:
-				osInfo.Major, _ = strconv.Atoi(p)
+				osInfo.Minor, _ = strconv.Atoi(p)
 			}
 		}
 	}

--- a/providers/windows/os_windows_test.go
+++ b/providers/windows/os_windows_test.go
@@ -20,6 +20,7 @@ package windows
 import (
 	"os/exec"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -99,12 +100,12 @@ func TestOperatingSystemMajorMinor(t *testing.T) {
 	var major, minor int
 	if stdout, err := exec.Command("powershell.exe", "-c", "[System.Environment]::OSVersion.Version.Major").Output(); err != nil {
 		t.Fatal(err)
-	} else if major, err = strconv.Atoi(string(stdout)); err != nil {
+	} else if major, err = strconv.Atoi(strings.TrimSpace(string(stdout))); err != nil {
 		t.Fatal(err)
 	}
 	if stdout, err := exec.Command("powershell.exe", "-c", "[System.Environment]::OSVersion.Version.Minor").Output(); err != nil {
 		t.Fatal(err)
-	} else if minor, err = strconv.Atoi(string(stdout)); err != nil {
+	} else if minor, err = strconv.Atoi(strings.TrimSpace(string(stdout))); err != nil {
 		t.Fatal(err)
 	}
 

--- a/providers/windows/os_windows_test.go
+++ b/providers/windows/os_windows_test.go
@@ -18,6 +18,8 @@
 package windows
 
 import (
+	"os/exec"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -90,4 +92,28 @@ func TestFixWindows11Naming(t *testing.T) {
 		fixWindows11Naming(tc.osInfo.Build, &tc.osInfo)
 		assert.Equal(t, tc.expectedName, tc.osInfo.Name)
 	}
+}
+
+func TestOperatingSystemMajorMinor(t *testing.T) {
+	// User PowerShell to get the expected OS version.
+	var major, minor int
+	if stdout, err := exec.Command("powershell.exe", "-c", "[System.Environment]::OSVersion.Version.Major").Output(); err != nil {
+		t.Fatal(err)
+	} else if major, err = strconv.Atoi(string(stdout)); err != nil {
+		t.Fatal(err)
+	}
+	if stdout, err := exec.Command("powershell.exe", "-c", "[System.Environment]::OSVersion.Version.Minor").Output(); err != nil {
+		t.Fatal(err)
+	} else if minor, err = strconv.Atoi(string(stdout)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify expected output.
+	osInfo, err := OperatingSystem()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, major, osInfo.Major)
+	assert.Equal(t, minor, osInfo.Minor)
 }


### PR DESCRIPTION
On Windows versions earlier than 10/2016, the `Major` version was getting overwritten with what would have been the `Minor` version, and the `Minor` version was not being set.

Windows 7:
Before fix:
```
"os": {
  "type": "windows",
  "family": "windows",
  "platform": "windows",
  "name": "Windows 7 Enterprise",
  "version": "6.1",
  "major": 1,
  "minor": 0,
  "patch": 0,
  "build": "7601.0"
},
```

With fix:
```
"os": {
  "type": "windows",
  "family": "windows",
  "platform": "windows",
  "name": "Windows 7 Enterprise",
  "version": "6.1",
  "major": 6,
  "minor": 1,
  "patch": 0,
  "build": "7601.0"
},
```

Windows 8:
Before fix:
```
"os": {
  "type": "windows",
  "family": "windows",
  "platform": "windows",
  "name": "Windows 8 Enterprise",
  "version": "6.2",
  "major": 2,
  "minor": 0,
  "patch": 0,
  "build": "9200.0"
},
```

With fix:
```
"os": {
  "type": "windows",
  "family": "windows",
  "platform": "windows",
  "name": "Windows 8 Enterprise",
  "version": "6.2",
  "major": 6,
  "minor": 2,
  "patch": 0,
  "build": "9200.0"
},
```

Win 10:
Separate code path, unimpacted, same before and after:
```
"os": {
  "type": "windows",
  "family": "windows",
  "platform": "windows",
  "name": "Windows 11 Pro",
  "version": "10.0",
  "major": 10,
  "minor": 0,
  "patch": 0,
  "build": "22621.1702"
},
```
