### PR TITLE
.github/workflows/release.yml - Pass GH_TOKEN to gh CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ jobs:
           -this-release HEAD | tee /tmp/release-notes.txt
 
       - name: draft GH release
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: >-
           gh release create "${{ inputs.version }}"
           --draft


### PR DESCRIPTION
Fix error

```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ github.token }}
```