### PR TITLE
.github/workflows/go.yml - Increase golangci-lint timeout

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           version: latest
           only-new-issues: true
-          args: --timeout=3m
+          args: --timeout=5m
           # Don't cache or restore ~/go/pkg. It conflicts with caching from setup-go@v4.
           skip-pkg-cache: true
 


### PR DESCRIPTION
On Windows we observed a timeout after 3m so increase it a bit longer. In most cases it finishes in about 1 minute.