### PR TITLE
system_test.go - Fix flaky TestProcesses

### DIFF
--- a/system_test.go
+++ b/system_test.go
@@ -298,6 +298,7 @@ func TestProcesses(t *testing.T) {
 		case errors.Is(err, syscall.ESRCH),
 			errors.Is(err, syscall.EPERM),
 			errors.Is(err, syscall.EINVAL),
+			errors.Is(err, syscall.ENOENT),
 			errors.Is(err, fs.ErrPermission):
 			continue
 		case err != nil:


### PR DESCRIPTION
If a process terminates while go-sysinfo is collecting info about it then ENOENT (no such file or directory) can occur. Ignore that while testing a live system.

Fixes #179