### PR TITLE
providers/linux/capabilities_linux.go - Refresh capability names

### DIFF
--- a/.changelog/184.txt
+++ b/.changelog/184.txt
@@ -1,0 +1,4 @@
+```release-note:enhancement
+linux: Update the Linux capability name mapping to add names for the
+`perfmon`, `bpf`, and `checkpoint_restore` capabilities.
+```

--- a/providers/linux/capabilities_linux.go
+++ b/providers/linux/capabilities_linux.go
@@ -28,7 +28,8 @@ import (
 // Generated with:
 //
 //	curl -s https://raw.githubusercontent.com/torvalds/linux/master/include/uapi/linux/capability.h | \
-//	grep -P '^#define CAP_\w+\s+\d+' | perl -pe 's/#define (\w+)\s+(\d+)/\2: "\1",/g'
+//	grep -P '^#define CAP_\w+\s+\d+' | \
+//	perl -pe 's/#define CAP_(\w+)\s+(\d+)/\2: "\L\1",/g'
 var capabilityNames = map[int]string{
 	0:  "chown",
 	1:  "dac_override",
@@ -68,6 +69,9 @@ var capabilityNames = map[int]string{
 	35: "wake_alarm",
 	36: "block_suspend",
 	37: "audit_read",
+	38: "perfmon",
+	39: "bpf",
+	40: "checkpoint_restore",
 }
 
 func capabilityName(num int) string {


### PR DESCRIPTION
Sync the list of Linux capability names from the kernel source as per the command listed in the code.

Closes #154