### PR TITLE
AIX: Added missing method FQDN for types.Host implementation

### DIFF
--- a/.changelog/185.txt
+++ b/.changelog/185.txt
@@ -1,3 +1,3 @@
-```release-note:enhancement
+```release-note:bug
 aix: Added missing method FQDN for types.Host implementation.
 ```

--- a/.changelog/185.txt
+++ b/.changelog/185.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+aix: Added missing method FQDN for types.Host implementation.
+```

--- a/providers/aix/host_aix_ppc64.go
+++ b/providers/aix/host_aix_ppc64.go
@@ -118,6 +118,10 @@ func (*host) Memory() (*types.HostMemoryInfo, error) {
 	return &mem, nil
 }
 
+func (h *host) FQDN() (string, error) {
+	return shared.FQDN()
+}
+
 func newHost() (*host, error) {
 	h := &host{}
 	r := &reader{}

--- a/providers/shared/fqdn.go
+++ b/providers/shared/fqdn.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build linux || darwin
+//go:build linux || darwin || aix
 
 package shared
 


### PR DESCRIPTION
Encountered this issue while building on AIX 7.3. I have added the missing implementation.

```
# github.com/elastic/go-sysinfo/providers/aix
/go/pkg/mod/github.com/elastic/go-sysinfo@v1.11.0/providers/aix/host_aix_ppc64.go:57:9: cannot use newHost() (value of type *host) as types.Host value in return statement: *host does not implement types.Host (missing method FQDN)
```