### PR TITLE
providers/linux: Fix linux Capabilities

### DIFF
--- a/.changelog/196.txt
+++ b/.changelog/196.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+linux: fix linux capabilities
+```

--- a/providers/linux/capabilities_linux.go
+++ b/providers/linux/capabilities_linux.go
@@ -83,40 +83,36 @@ func capabilityName(num int) string {
 	return strconv.Itoa(num)
 }
 
-func readCapabilities(content []byte) (*types.CapabilityInfo, error) {
-	var cap types.CapabilityInfo
-
-	err := parseKeyValue(content, ':', func(key, value []byte) error {
+func decodeCapabilityLine(content string, capInfo *types.CapabilityInfo) error {
+	return parseKeyValue([]byte(content), ':', func(key, value []byte) error {
 		var err error
 		switch string(key) {
 		case "CapInh":
-			cap.Inheritable, err = decodeBitMap(string(value), capabilityName)
+			capInfo.Inheritable, err = decodeBitMap(string(value), capabilityName)
 			if err != nil {
 				return err
 			}
 		case "CapPrm":
-			cap.Permitted, err = decodeBitMap(string(value), capabilityName)
+			capInfo.Permitted, err = decodeBitMap(string(value), capabilityName)
 			if err != nil {
 				return err
 			}
 		case "CapEff":
-			cap.Effective, err = decodeBitMap(string(value), capabilityName)
+			capInfo.Effective, err = decodeBitMap(string(value), capabilityName)
 			if err != nil {
 				return err
 			}
 		case "CapBnd":
-			cap.Bounding, err = decodeBitMap(string(value), capabilityName)
+			capInfo.Bounding, err = decodeBitMap(string(value), capabilityName)
 			if err != nil {
 				return err
 			}
 		case "CapAmb":
-			cap.Ambient, err = decodeBitMap(string(value), capabilityName)
+			capInfo.Ambient, err = decodeBitMap(string(value), capabilityName)
 			if err != nil {
 				return err
 			}
 		}
 		return nil
 	})
-
-	return &cap, err
 }

--- a/system_test.go
+++ b/system_test.go
@@ -310,3 +310,25 @@ func TestProcesses(t *testing.T) {
 			info.StartTime)
 	}
 }
+
+func TestCapabilities(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("capabilities is linux only")
+	}
+	init, err := Process(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, ok := init.(types.Capabilities)
+	if !ok {
+		t.Fatal("capabilities is expected to be implemented for linux")
+	}
+	capInfo, err := v.Capabilities()
+	if err != nil {
+		t.Fatal(err)
+	}
+	totalCaps := 41
+	assert.EqualValues(t, len(capInfo.Permitted), totalCaps)
+	assert.EqualValues(t, len(capInfo.Effective), totalCaps)
+	assert.EqualValues(t, len(capInfo.Bounding), totalCaps)
+}


### PR DESCRIPTION
I believe this never worked, as readCapabilities() expected a Capabilities line but was passed the full file as input, it also would allocate its own CapabilityInfo and return it, even though it would fill one member.

So change all this:
  - Scan the file line by line, as to avoid loading a full file into memory,
    then parse out only the desired lines and pass down.
  - Pass the structure as a parameter and let each member be filled.
  - Error out if we failed to report at least one of the capabilities.
  - Add a test against init(1) as it will """always""" be run as root and have
    all capabilities, test is a bit conservative but should be ok for now.