### PR TITLE
Add support for custom hostfs in linux metrics, cleanup linux code

### DIFF
--- a/.changelog/198.txt
+++ b/.changelog/198.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+Add API for metrics from an alternate filesystem root
+```

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -23,21 +23,29 @@ import (
 	"github.com/elastic/go-sysinfo/types"
 )
 
-var (
-	hostProvider    HostProvider
-	processProvider ProcessProvider
-)
+type HostFSCreator = func(string) HostProvider
+type ProcessFSCreator = func(string) ProcessProvider
 
+// HostProvider defines interfaces that provide host-specific metrics
 type HostProvider interface {
 	Host() (types.Host, error)
 }
 
+// ProcessProvider defines interfaces that provide process-specific metrics
 type ProcessProvider interface {
 	Processes() ([]types.Process, error)
 	Process(pid int) (types.Process, error)
 	Self() (types.Process, error)
 }
 
+var (
+	hostProvider            HostProvider
+	hostProviderWithRoot    HostFSCreator
+	processProvider         ProcessProvider
+	processProviderWithRoot ProcessFSCreator
+)
+
+// Register a metrics provider. `provider` should implement one or more of `ProcessProvider`, `HostProvider`, `HostFSCreator` or `ProcessFSCreator`
 func Register(provider interface{}) {
 	if h, ok := provider.(HostProvider); ok {
 		if hostProvider != nil {
@@ -52,7 +60,50 @@ func Register(provider interface{}) {
 		}
 		processProvider = p
 	}
+
+	if creator, ok := provider.(HostFSCreator); ok {
+		if hostProviderWithRoot != nil {
+			panic("hostProviderWithRoot already registered")
+		}
+		hostProviderWithRoot = creator
+	}
+
+	if creator, ok := provider.(ProcessFSCreator); ok {
+		if processProviderWithRoot != nil {
+			panic("processProviderWithRoot is already registered")
+		}
+		processProviderWithRoot = creator
+	}
 }
 
-func GetHostProvider() HostProvider       { return hostProvider }
-func GetProcessProvider() ProcessProvider { return processProvider }
+// GetHostProvider returns the HostProvider registered for the system. May return nil.
+func GetHostProvider() HostProvider {
+	if hostProviderWithRoot != nil {
+		return hostProviderWithRoot("")
+	}
+	return hostProvider
+}
+
+// GetHostProviderWithRoot creates a host provider for the given sysfs root. May return nil.
+func GetHostProviderWithRoot(hostFS string) HostProvider {
+	if hostProviderWithRoot != nil {
+		return hostProviderWithRoot(hostFS)
+	}
+	return hostProvider
+}
+
+// GetProcessProvider returns the ProcessProvider registered on the system. May return nil.
+func GetProcessProvider() ProcessProvider {
+	if processProviderWithRoot != nil {
+		return processProviderWithRoot("")
+	}
+	return processProvider
+}
+
+// GetProcessProviderWithRoot creates a process provider for the sysfs root. May return nil
+func GetProcessProviderWithRoot(hostFS string) ProcessProvider {
+	if processProviderWithRoot != nil {
+		return processProviderWithRoot(hostFS)
+	}
+	return processProvider
+}

--- a/providers/linux/container.go
+++ b/providers/linux/container.go
@@ -21,7 +21,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 )
 
@@ -29,7 +28,7 @@ const procOneCgroup = "/proc/1/cgroup"
 
 // IsContainerized returns true if this process is containerized.
 func IsContainerized() (bool, error) {
-	data, err := ioutil.ReadFile(procOneCgroup)
+	data, err := os.ReadFile(procOneCgroup)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return false, nil

--- a/providers/linux/host_linux.go
+++ b/providers/linux/host_linux.go
@@ -20,7 +20,6 @@ package linux
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -35,7 +34,10 @@ import (
 )
 
 func init() {
-	registry.Register(newLinuxSystem(""))
+	// register wrappers that implement the HostFS versions of the ProcessProvider and HostProvider
+	registry.Register(func(hostfs string) registry.HostProvider { return newLinuxSystem(hostfs) })
+	registry.Register(func(hostfs string) registry.ProcessProvider { return newLinuxSystem(hostfs) })
+
 }
 
 type linuxSystem struct {
@@ -60,28 +62,33 @@ type host struct {
 	info   types.HostInfo
 }
 
+// Info returns host info
 func (h *host) Info() types.HostInfo {
 	return h.info
 }
 
+// Memory returns memory info
 func (h *host) Memory() (*types.HostMemoryInfo, error) {
-	content, err := ioutil.ReadFile(h.procFS.path("meminfo"))
+	path := h.procFS.path("meminfo")
+	content, err := os.ReadFile(path)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error reading meminfo file %s: %w", path, err)
 	}
 
 	return parseMemInfo(content)
 }
 
+// FQDN returns the Fully Qualified Domain Name
 func (h *host) FQDN() (string, error) {
 	return shared.FQDN()
 }
 
 // VMStat reports data from /proc/vmstat on linux.
 func (h *host) VMStat() (*types.VMStatInfo, error) {
-	content, err := ioutil.ReadFile(h.procFS.path("vmstat"))
+	path := h.procFS.path("vmstat")
+	content, err := os.ReadFile(path)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error reading vmstat file %s: %w", path, err)
 	}
 
 	return parseVMStat(content)
@@ -91,7 +98,7 @@ func (h *host) VMStat() (*types.VMStatInfo, error) {
 func (h *host) LoadAverage() (*types.LoadAverageInfo, error) {
 	loadAvg, err := h.procFS.LoadAvg()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error fetching load averages: %w", err)
 	}
 
 	return &types.LoadAverageInfo{
@@ -103,31 +110,34 @@ func (h *host) LoadAverage() (*types.LoadAverageInfo, error) {
 
 // NetworkCounters reports data from /proc/net on linux
 func (h *host) NetworkCounters() (*types.NetworkCountersInfo, error) {
-	snmpRaw, err := ioutil.ReadFile(h.procFS.path("net/snmp"))
+	snmpFile := h.procFS.path("net/snmp")
+	snmpRaw, err := os.ReadFile(snmpFile)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error fetching net/snmp file %s: %w", snmpFile, err)
 	}
 	snmp, err := getNetSnmpStats(snmpRaw)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error parsing SNMP stats: %w", err)
 	}
 
-	netstatRaw, err := ioutil.ReadFile(h.procFS.path("net/netstat"))
+	netstatFile := h.procFS.path("net/netstat")
+	netstatRaw, err := os.ReadFile(netstatFile)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error fetching net/netstat file %s: %w", netstatFile, err)
 	}
 	netstat, err := getNetstatStats(netstatRaw)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error parsing netstat file: %w", err)
 	}
 
 	return &types.NetworkCountersInfo{SNMP: snmp, Netstat: netstat}, nil
 }
 
+// CPUTime returns host CPU usage metrics
 func (h *host) CPUTime() (types.CPUTimes, error) {
 	stat, err := h.procFS.Stat()
 	if err != nil {
-		return types.CPUTimes{}, err
+		return types.CPUTimes{}, fmt.Errorf("error fetching CPU stats: %w", err)
 	}
 
 	return types.CPUTimes{

--- a/providers/linux/process_linux.go
+++ b/providers/linux/process_linux.go
@@ -19,7 +19,7 @@ package linux
 
 import (
 	"bytes"
-	"io/ioutil"
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -32,10 +32,11 @@ import (
 
 const userHz = 100
 
+// Processes returns a list of processes on the system
 func (s linuxSystem) Processes() ([]types.Process, error) {
 	procs, err := s.procFS.AllProcs()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error fetching all processes: %w", err)
 	}
 
 	processes := make([]types.Process, 0, len(procs))
@@ -45,19 +46,21 @@ func (s linuxSystem) Processes() ([]types.Process, error) {
 	return processes, nil
 }
 
+// Process returns the given process
 func (s linuxSystem) Process(pid int) (types.Process, error) {
-	proc, err := s.procFS.NewProc(pid)
+	proc, err := s.procFS.Proc(pid)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error fetching process: %w", err)
 	}
 
 	return &process{Proc: proc, fs: s.procFS}, nil
 }
 
+// Self returns process info for the caller's own PID
 func (s linuxSystem) Self() (types.Process, error) {
 	proc, err := s.procFS.Self()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error fetching self process info: %w", err)
 	}
 
 	return &process{Proc: proc, fs: s.procFS}, nil
@@ -69,19 +72,21 @@ type process struct {
 	info *types.ProcessInfo
 }
 
+// PID returns the PID of the process
 func (p *process) PID() int {
 	return p.Proc.PID
 }
 
+// Parent returns the parent process
 func (p *process) Parent() (types.Process, error) {
 	info, err := p.Info()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error fetching process info: %w", err)
 	}
 
-	proc, err := p.fs.NewProc(info.PPID)
+	proc, err := p.fs.Proc(info.PPID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error fetching data for parent process: %w", err)
 	}
 
 	return &process{Proc: proc, fs: p.fs}, nil
@@ -91,8 +96,8 @@ func (p *process) path(pa ...string) string {
 	return p.fs.path(append([]string{strconv.Itoa(p.PID())}, pa...)...)
 }
 
+// CWD returns the current working directory
 func (p *process) CWD() (string, error) {
-	// TODO: add CWD to procfs
 	cwd, err := os.Readlink(p.path("cwd"))
 	if os.IsNotExist(err) {
 		return "", nil
@@ -101,34 +106,35 @@ func (p *process) CWD() (string, error) {
 	return cwd, err
 }
 
+// Info returns basic process info
 func (p *process) Info() (types.ProcessInfo, error) {
 	if p.info != nil {
 		return *p.info, nil
 	}
 
-	stat, err := p.NewStat()
+	stat, err := p.Stat()
 	if err != nil {
-		return types.ProcessInfo{}, err
+		return types.ProcessInfo{}, fmt.Errorf("error fetching process stats: %w", err)
 	}
 
 	exe, err := p.Executable()
 	if err != nil {
-		return types.ProcessInfo{}, err
+		return types.ProcessInfo{}, fmt.Errorf("error fetching process executable info: %w", err)
 	}
 
 	args, err := p.CmdLine()
 	if err != nil {
-		return types.ProcessInfo{}, err
+		return types.ProcessInfo{}, fmt.Errorf("error fetching process cmdline: %w", err)
 	}
 
 	cwd, err := p.CWD()
 	if err != nil {
-		return types.ProcessInfo{}, err
+		return types.ProcessInfo{}, fmt.Errorf("error fetching process CWD: %w", err)
 	}
 
 	bootTime, err := bootTime(p.fs.FS)
 	if err != nil {
-		return types.ProcessInfo{}, err
+		return types.ProcessInfo{}, fmt.Errorf("error fetching boot time: %w", err)
 	}
 
 	p.info = &types.ProcessInfo{
@@ -144,8 +150,9 @@ func (p *process) Info() (types.ProcessInfo, error) {
 	return *p.info, nil
 }
 
+// Memory returns memory stats for the process
 func (p *process) Memory() (types.MemoryInfo, error) {
-	stat, err := p.NewStat()
+	stat, err := p.Stat()
 	if err != nil {
 		return types.MemoryInfo{}, err
 	}
@@ -156,8 +163,9 @@ func (p *process) Memory() (types.MemoryInfo, error) {
 	}, nil
 }
 
+// CPUTime returns CPU usage time for the process
 func (p *process) CPUTime() (types.CPUTimes, error) {
-	stat, err := p.NewStat()
+	stat, err := p.Stat()
 	if err != nil {
 		return types.CPUTimes{}, err
 	}
@@ -178,9 +186,9 @@ func (p *process) OpenHandleCount() (int, error) {
 	return p.Proc.FileDescriptorsLen()
 }
 
+// Environment returns a list of environment variables for the process
 func (p *process) Environment() (map[string]string, error) {
-	// TODO: add Environment to procfs
-	content, err := ioutil.ReadFile(p.path("environ"))
+	content, err := os.ReadFile(p.path("environ"))
 	if err != nil {
 		return nil, err
 	}
@@ -204,8 +212,9 @@ func (p *process) Environment() (map[string]string, error) {
 	return env, nil
 }
 
+// Seccomp returns seccomp info for the process
 func (p *process) Seccomp() (*types.SeccompInfo, error) {
-	content, err := ioutil.ReadFile(p.path("status"))
+	content, err := os.ReadFile(p.path("status"))
 	if err != nil {
 		return nil, err
 	}
@@ -213,8 +222,9 @@ func (p *process) Seccomp() (*types.SeccompInfo, error) {
 	return readSeccompFields(content)
 }
 
+// Capabilities returns capability info for the process
 func (p *process) Capabilities() (*types.CapabilityInfo, error) {
-	content, err := ioutil.ReadFile(p.path("status"))
+	content, err := os.ReadFile(p.path("status"))
 	if err != nil {
 		return nil, err
 	}
@@ -222,8 +232,9 @@ func (p *process) Capabilities() (*types.CapabilityInfo, error) {
 	return readCapabilities(content)
 }
 
+// User returns user info for the process
 func (p *process) User() (types.UserInfo, error) {
-	content, err := ioutil.ReadFile(p.path("status"))
+	content, err := os.ReadFile(p.path("status"))
 	if err != nil {
 		return types.UserInfo{}, err
 	}
@@ -249,28 +260,31 @@ func (p *process) User() (types.UserInfo, error) {
 		}
 		return nil
 	})
+	if err != nil {
+		return user, fmt.Errorf("error partsing key-values in user data: %w", err)
+	}
 
 	return user, nil
 }
 
 // NetworkStats reports network stats for an individual PID.
 func (p *process) NetworkCounters() (*types.NetworkCountersInfo, error) {
-	snmpRaw, err := ioutil.ReadFile(p.path("net/snmp"))
+	snmpRaw, err := os.ReadFile(p.path("net/snmp"))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error reading net/snmp file: %w", err)
 	}
 	snmp, err := getNetSnmpStats(snmpRaw)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error parsing SNMP network data: %w", err)
 	}
 
-	netstatRaw, err := ioutil.ReadFile(p.path("net/netstat"))
+	netstatRaw, err := os.ReadFile(p.path("net/netstat"))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error reading net/netstat file: %w", err)
 	}
 	netstat, err := getNetstatStats(netstatRaw)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error parsing netstat file: %w", err)
 	}
 
 	return &types.NetworkCountersInfo{SNMP: snmp, Netstat: netstat}, nil

--- a/providers/linux/util.go
+++ b/providers/linux/util.go
@@ -18,11 +18,9 @@
 package linux
 
 import (
-	"bufio"
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"strconv"
 )
 
@@ -50,34 +48,9 @@ func parseKeyValue(content []byte, separator byte, callback func(key, value []by
 	return nil
 }
 
-func findValue(filename, separator, key string) (string, error) {
-	content, err := ioutil.ReadFile(filename)
-	if err != nil {
-		return "", err
-	}
-
-	var line []byte
-	sc := bufio.NewScanner(bytes.NewReader(content))
-	for sc.Scan() {
-		if bytes.HasPrefix(sc.Bytes(), []byte(key)) {
-			line = sc.Bytes()
-			break
-		}
-	}
-	if len(line) == 0 {
-		return "", fmt.Errorf("%v not found", key)
-	}
-
-	parts := bytes.SplitN(line, []byte(separator), 2)
-	if len(parts) != 2 {
-		return "", fmt.Errorf("unexpected line format for '%v'", string(line))
-	}
-
-	return string(bytes.TrimSpace(parts[1])), nil
-}
-
-func decodeBitMap(s string, lookupName func(int) string) ([]string, error) {
-	mask, err := strconv.ParseUint(s, 16, 64)
+// decodeBitMap parses the bitmap provided by value, and looks up any set bits in the table provided by `lookupName`
+func decodeBitMap(bmpValue string, lookupName func(int) string) ([]string, error) {
+	mask, err := strconv.ParseUint(bmpValue, 16, 64)
 	if err != nil {
 		return nil, err
 	}
@@ -93,6 +66,7 @@ func decodeBitMap(s string, lookupName func(int) string) ([]string, error) {
 	return names, nil
 }
 
+// parses a meminfo field, returning either a raw numerical value, or the kB value converted to bytes
 func parseBytesOrNumber(data []byte) (uint64, error) {
 	parts := bytes.Fields(data)
 

--- a/system.go
+++ b/system.go
@@ -52,6 +52,14 @@ func Host() (types.Host, error) {
 	return provider.Host()
 }
 
+func HostFS(hostfs string) (types.Host, error) {
+	provider := registry.GetHostProviderWithRoot(hostfs)
+	if provider == nil {
+		return nil, types.ErrNotImplemented
+	}
+	return provider.Host()
+}
+
 // Process returns a types.Process object representing the process associated
 // with the given PID. The types.Process object can be used to query information
 // about the process.  If process information collection is not implemented for

--- a/system.go
+++ b/system.go
@@ -52,6 +52,8 @@ func Host() (types.Host, error) {
 	return provider.Host()
 }
 
+// HostFS is the same as Host, but allows for a custom root hostfs mountpoint
+// a custom filesystem root is only supported on linux, and this will fallback to the default provider on other platforms
 func HostFS(hostfs string) (types.Host, error) {
 	provider := registry.GetHostProviderWithRoot(hostfs)
 	if provider == nil {
@@ -72,11 +74,31 @@ func Process(pid int) (types.Process, error) {
 	return provider.Process(pid)
 }
 
+// ProcessFS is the same as Process, but allows for a custom root hostfs mountpoint
+// a custom filesystem root is only supported on linux, and this will fallback to the default provider on other platforms
+func ProcessFS(hostfs string, pid int) (types.Process, error) {
+	provider := registry.GetProcessProviderWithRoot(hostfs)
+	if provider == nil {
+		return nil, types.ErrNotImplemented
+	}
+	return provider.Process(pid)
+}
+
 // Processes return a list of all processes. If process information collection
 // is not implemented for this platform then types.ErrNotImplemented is
 // returned.
 func Processes() ([]types.Process, error) {
 	provider := registry.GetProcessProvider()
+	if provider == nil {
+		return nil, types.ErrNotImplemented
+	}
+	return provider.Processes()
+}
+
+// ProcessesFS is the same as Processes, but allows for a custom root hostfs mountpoint
+// a custom filesystem root is only supported on linux, and this will fallback to the default provider on other platforms
+func ProcessesFS(hostfs string) ([]types.Process, error) {
+	provider := registry.GetProcessProviderWithRoot(hostfs)
 	if provider == nil {
 		return nil, types.ErrNotImplemented
 	}

--- a/system_test.go
+++ b/system_test.go
@@ -74,6 +74,19 @@ var expectedProcessFeatures = map[string]*ProcessFeatures{
 	},
 }
 
+func TestSystemHostFS(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("test is linux-only")
+	}
+
+	handler, err := HostFS("providers/linux/testdata/ubuntu1710")
+	require.NoError(t, err)
+	memInfo, err := handler.Memory()
+	require.NoError(t, err)
+	// make sure we read the testdata file
+	require.Equal(t, memInfo.Free, uint64(2612703232))
+}
+
 func TestProcessFeaturesMatrix(t *testing.T) {
 	const GOOS = runtime.GOOS
 	var features ProcessFeatures


### PR DESCRIPTION
closes https://github.com/elastic/go-sysinfo/issues/12

This adds a set of new public methods to `system.go` to allow for metrics from a custom filesystem root under linux.

The API design feels a bit awkward at points, but my goal was to make a non-breaking change that mostly followed the existing design idioms of the library. 

The underlying linux implementation already had support for a custom filesystem root, but the option wasn't exposed publicly, so this is a fairly small change.