### PR TITLE
Allow FQDN lookup functions to take context

### DIFF
--- a/providers/aix/host_aix_ppc64.go
+++ b/providers/aix/host_aix_ppc64.go
@@ -30,6 +30,7 @@ package aix
 import "C"
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -128,8 +129,8 @@ func (*host) Memory() (*types.HostMemoryInfo, error) {
 	return &mem, nil
 }
 
-func (h *host) FQDN() (string, error) {
-	return shared.FQDN()
+func (h *host) FQDN(ctx context.Context) (string, error) {
+	return shared.FQDN(ctx)
 }
 
 func newHost() (*host, error) {

--- a/providers/darwin/host_darwin.go
+++ b/providers/darwin/host_darwin.go
@@ -20,6 +20,7 @@
 package darwin
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -139,8 +140,8 @@ func (h *host) Memory() (*types.HostMemoryInfo, error) {
 	return &mem, nil
 }
 
-func (h *host) FQDN() (string, error) {
-	return shared.FQDN()
+func (h *host) FQDN(ctx context.Context) (string, error) {
+	return shared.FQDN(ctx)
 }
 
 func (h *host) LoadAverage() (*types.LoadAverageInfo, error) {

--- a/providers/linux/host_fqdn_integration_docker_linux_test.go
+++ b/providers/linux/host_fqdn_integration_docker_linux_test.go
@@ -20,8 +20,10 @@
 package linux
 
 import (
+	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -32,7 +34,10 @@ func TestHost_FQDN_set(t *testing.T) {
 		t.Fatal(fmt.Errorf("could not get host information: %w", err))
 	}
 
-	gotFQDN, err := host.FQDN()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	gotFQDN, err := host.FQDN(ctx)
 	require.NoError(t, err)
 	if gotFQDN != wantFQDN {
 		t.Errorf("got FQDN %q, want: %q", gotFQDN, wantFQDN)
@@ -45,7 +50,10 @@ func TestHost_FQDN_not_set(t *testing.T) {
 		t.Fatal(fmt.Errorf("could not get host information: %w", err))
 	}
 
-	gotFQDN, err := host.FQDN()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	gotFQDN, err := host.FQDN(ctx)
 	require.NoError(t, err)
 	hostname := host.Info().Hostname
 	if gotFQDN != hostname {

--- a/providers/linux/host_linux.go
+++ b/providers/linux/host_linux.go
@@ -18,6 +18,7 @@
 package linux
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -73,8 +74,8 @@ func (h *host) Memory() (*types.HostMemoryInfo, error) {
 	return parseMemInfo(content)
 }
 
-func (h *host) FQDN() (string, error) {
-	return shared.FQDN()
+func (h *host) FQDN(ctx context.Context) (string, error) {
+	return shared.FQDN(ctx)
 }
 
 // VMStat reports data from /proc/vmstat on linux.

--- a/providers/shared/fqdn.go
+++ b/providers/shared/fqdn.go
@@ -20,6 +20,7 @@
 package shared
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
@@ -40,18 +41,18 @@ import (
 //
 //  4. If steps 2 and 3 both fail, an empty string is returned as the FQDN along with
 //     errors from those steps.
-func FQDN() (string, error) {
+func FQDN(ctx context.Context) (string, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
 		return "", fmt.Errorf("could not get hostname to look for FQDN: %w", err)
 	}
 
-	return fqdn(hostname)
+	return fqdn(ctx, hostname)
 }
 
-func fqdn(hostname string) (string, error) {
+func fqdn(ctx context.Context, hostname string) (string, error) {
 	var errs error
-	cname, err := net.LookupCNAME(hostname)
+	cname, err := net.DefaultResolver.LookupCNAME(ctx, hostname)
 	if err != nil {
 		errs = fmt.Errorf("could not get FQDN, all methods failed: failed looking up CNAME: %w",
 			err)
@@ -60,13 +61,13 @@ func fqdn(hostname string) (string, error) {
 		return strings.ToLower(strings.TrimSuffix(cname, ".")), nil
 	}
 
-	ips, err := net.LookupIP(hostname)
+	ips, err := net.DefaultResolver.LookupIPAddr(ctx, hostname)
 	if err != nil {
 		errs = fmt.Errorf("%s: failed looking up IP: %w", errs, err)
 	}
 
 	for _, ip := range ips {
-		names, err := net.LookupAddr(ip.String())
+		names, err := net.DefaultResolver.LookupAddr(ctx, ip.String())
 		if err != nil || len(names) == 0 {
 			continue
 		}

--- a/providers/windows/host_windows.go
+++ b/providers/windows/host_windows.go
@@ -18,6 +18,7 @@
 package windows
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -84,7 +85,7 @@ func (h *host) Memory() (*types.HostMemoryInfo, error) {
 	}, nil
 }
 
-func (h *host) FQDN() (string, error) {
+func (h *host) FQDN(_ context.Context) (string, error) {
 	fqdn, err := getComputerNameEx(stdwindows.ComputerNamePhysicalDnsFullyQualified)
 	if err != nil {
 		return "", fmt.Errorf("could not get windows FQDN: %s", err)

--- a/types/host.go
+++ b/types/host.go
@@ -17,7 +17,10 @@
 
 package types
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 // Host is the interface that wraps methods for returning Host stats
 // It may return partial information if the provider
@@ -28,7 +31,7 @@ type Host interface {
 	Memory() (*HostMemoryInfo, error)
 
 	// FQDN returns the fully-qualified domain name of the host, lowercased.
-	FQDN() (string, error)
+	FQDN(ctx context.Context) (string, error)
 }
 
 // NetworkCounters represents network stats from /proc/net


### PR DESCRIPTION
This PR changes the FQDN lookup functions to take a `context.Context`, thus allowing callers of these functions to pass a context with a timeout to prevent indefinitely waiting for DNS resolution.