### PR TITLE
HostInfo.NativeArchitecture support older Windows builds

### DIFF
--- a/.changelog/201.txt
+++ b/.changelog/201.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+HostInfo.NativeArchitecture is not available on Windows system prior Windows 10 version 1709.
+```


### PR DESCRIPTION
Function [IsWow64Process2](https://learn.microsoft.com/en-us/windows/win32/api/wow64apiset/nf-wow64apiset-iswow64process2) was introduced in Windows 10 version 1709, therefore missing procedure is not an error on earlier Windows builds.

Note:
Only x86 (32 bit) applications can be run on Windows 10 on ARM. Windows 11 on ARM also supports x86_64 (64 bit) applications.