### PR TITLE
Add "skip-changelog" label to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
       - "elastic/observablt-ci"
     labels:
       - dependencies
+      - skip-changelog
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
This will add the `skip-changelog` label to the dependabot PR so the check is skipped.