### PR TITLE
Replace usages of the deprecated io/ioutil pkg

### DIFF
--- a/providers/aix/os_aix_ppc64.go
+++ b/providers/aix/os_aix_ppc64.go
@@ -21,7 +21,7 @@ package aix
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 
@@ -40,7 +40,7 @@ func getOSInfo() (*types.OSInfo, error) {
 	}
 
 	// Retrieve build version from "/proc/version".
-	procVersion, err := ioutil.ReadFile("/proc/version")
+	procVersion, err := os.ReadFile("/proc/version")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get OS info: cannot open /proc/version: %w", err)
 	}

--- a/providers/aix/process_aix_ppc64.go
+++ b/providers/aix/process_aix_ppc64.go
@@ -51,7 +51,7 @@ import (
 func (aixSystem) Processes() ([]types.Process, error) {
 	// Retrieve processes using /proc instead of calling
 	// getprocs which will also retrieve kernel threads.
-	files, err := ioutil.ReadDir("/proc")
+	files, err := os.ReadDir("/proc")
 	if err != nil {
 		return nil, fmt.Errorf("error while reading /proc: %w", err)
 	}

--- a/providers/darwin/os.go
+++ b/providers/darwin/os.go
@@ -19,7 +19,7 @@ package darwin
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 
@@ -37,7 +37,7 @@ const (
 )
 
 func OperatingSystem() (*types.OSInfo, error) {
-	data, err := ioutil.ReadFile(systemVersionPlist)
+	data, err := os.ReadFile(systemVersionPlist)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read plist file: %w", err)
 	}

--- a/providers/linux/container.go
+++ b/providers/linux/container.go
@@ -21,7 +21,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 )
 
@@ -29,7 +28,7 @@ const procOneCgroup = "/proc/1/cgroup"
 
 // IsContainerized returns true if this process is containerized.
 func IsContainerized() (bool, error) {
-	data, err := ioutil.ReadFile(procOneCgroup)
+	data, err := os.ReadFile(procOneCgroup)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return false, nil

--- a/providers/linux/host_linux.go
+++ b/providers/linux/host_linux.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -65,7 +64,7 @@ func (h *host) Info() types.HostInfo {
 }
 
 func (h *host) Memory() (*types.HostMemoryInfo, error) {
-	content, err := ioutil.ReadFile(h.procFS.path("meminfo"))
+	content, err := os.ReadFile(h.procFS.path("meminfo"))
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +82,7 @@ func (h *host) FQDN() (string, error) {
 
 // VMStat reports data from /proc/vmstat on linux.
 func (h *host) VMStat() (*types.VMStatInfo, error) {
-	content, err := ioutil.ReadFile(h.procFS.path("vmstat"))
+	content, err := os.ReadFile(h.procFS.path("vmstat"))
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +106,7 @@ func (h *host) LoadAverage() (*types.LoadAverageInfo, error) {
 
 // NetworkCounters reports data from /proc/net on linux
 func (h *host) NetworkCounters() (*types.NetworkCountersInfo, error) {
-	snmpRaw, err := ioutil.ReadFile(h.procFS.path("net/snmp"))
+	snmpRaw, err := os.ReadFile(h.procFS.path("net/snmp"))
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +115,7 @@ func (h *host) NetworkCounters() (*types.NetworkCountersInfo, error) {
 		return nil, err
 	}
 
-	netstatRaw, err := ioutil.ReadFile(h.procFS.path("net/netstat"))
+	netstatRaw, err := os.ReadFile(h.procFS.path("net/netstat"))
 	if err != nil {
 		return nil, err
 	}

--- a/providers/linux/machineid.go
+++ b/providers/linux/machineid.go
@@ -20,7 +20,6 @@ package linux
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/elastic/go-sysinfo/types"
@@ -35,7 +34,7 @@ func MachineID() (string, error) {
 	var err error
 
 	for _, file := range machineIDFiles {
-		contents, err = ioutil.ReadFile(file)
+		contents, err = os.ReadFile(file)
 		if err != nil {
 			if os.IsNotExist(err) {
 				// Try next location

--- a/providers/linux/process_linux.go
+++ b/providers/linux/process_linux.go
@@ -19,7 +19,6 @@ package linux
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -180,7 +179,7 @@ func (p *process) OpenHandleCount() (int, error) {
 
 func (p *process) Environment() (map[string]string, error) {
 	// TODO: add Environment to procfs
-	content, err := ioutil.ReadFile(p.path("environ"))
+	content, err := os.ReadFile(p.path("environ"))
 	if err != nil {
 		return nil, err
 	}
@@ -205,7 +204,7 @@ func (p *process) Environment() (map[string]string, error) {
 }
 
 func (p *process) Seccomp() (*types.SeccompInfo, error) {
-	content, err := ioutil.ReadFile(p.path("status"))
+	content, err := os.ReadFile(p.path("status"))
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +213,7 @@ func (p *process) Seccomp() (*types.SeccompInfo, error) {
 }
 
 func (p *process) Capabilities() (*types.CapabilityInfo, error) {
-	content, err := ioutil.ReadFile(p.path("status"))
+	content, err := os.ReadFile(p.path("status"))
 	if err != nil {
 		return nil, err
 	}
@@ -223,7 +222,7 @@ func (p *process) Capabilities() (*types.CapabilityInfo, error) {
 }
 
 func (p *process) User() (types.UserInfo, error) {
-	content, err := ioutil.ReadFile(p.path("status"))
+	content, err := os.ReadFile(p.path("status"))
 	if err != nil {
 		return types.UserInfo{}, err
 	}
@@ -255,7 +254,7 @@ func (p *process) User() (types.UserInfo, error) {
 
 // NetworkStats reports network stats for an individual PID.
 func (p *process) NetworkCounters() (*types.NetworkCountersInfo, error) {
-	snmpRaw, err := ioutil.ReadFile(p.path("net/snmp"))
+	snmpRaw, err := os.ReadFile(p.path("net/snmp"))
 	if err != nil {
 		return nil, err
 	}
@@ -264,7 +263,7 @@ func (p *process) NetworkCounters() (*types.NetworkCountersInfo, error) {
 		return nil, err
 	}
 
-	netstatRaw, err := ioutil.ReadFile(p.path("net/netstat"))
+	netstatRaw, err := os.ReadFile(p.path("net/netstat"))
 	if err != nil {
 		return nil, err
 	}

--- a/providers/linux/util.go
+++ b/providers/linux/util.go
@@ -22,7 +22,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 )
 
@@ -51,7 +51,7 @@ func parseKeyValue(content []byte, separator byte, callback func(key, value []by
 }
 
 func findValue(filename, separator, key string) (string, error) {
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Replace usages of the deprecated io/ioutil pkg.

```
[git-generate]
cat << EOF | go run github.com/uber-go/gopatch@v0.4.0 ./...
@@
@@
-import "io/ioutil"
+import "os"

-ioutil.ReadFile(...)
+os.ReadFile(...)

@@
@@
-ioutil.ReadDir(...)
+os.ReadDir(...)
EOF
```