### PR TITLE
Fix bug with NativeArchitecture ending in newline

### DIFF
--- a/.changelog/223.txt
+++ b/.changelog/223.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-all: Remove newline from HostInfo.NativeArchitecture
+linux: Remove newline from HostInfo.NativeArchitecture value.
 ```

--- a/.changelog/223.txt
+++ b/.changelog/223.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+all: Remove newline from HostInfo.NativeArchitecture
+```

--- a/providers/linux/arch_linux.go
+++ b/providers/linux/arch_linux.go
@@ -81,5 +81,5 @@ func NativeArchitecture() (string, error) {
 	nativeArch := string(data)
 	nativeArch = strings.TrimRight(nativeArch, "\n")
 
-	return string(data), nil
+	return nativeArch, nil
 }

--- a/providers/linux/arch_linux_test.go
+++ b/providers/linux/arch_linux_test.go
@@ -18,6 +18,7 @@
 package linux
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,10 +28,12 @@ func TestArchitecture(t *testing.T) {
 	a, err := Architecture()
 	assert.NoError(t, err)
 	assert.NotEmpty(t, a)
+	assert.NotRegexp(t, regexp.MustCompile("^.*\n+$"), a, "should not end in newlines")
 }
 
 func TestNativeArchitecture(t *testing.T) {
 	a, err := NativeArchitecture()
 	assert.NoError(t, err)
 	assert.NotEmpty(t, a)
+	assert.NotRegexp(t, regexp.MustCompile("^.*\n+$"), a, "should not end in newlines")
 }

--- a/providers/linux/arch_linux_test.go
+++ b/providers/linux/arch_linux_test.go
@@ -24,16 +24,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var reNewline = regexp.MustCompile("^.*\n+$")
+
 func TestArchitecture(t *testing.T) {
 	a, err := Architecture()
 	assert.NoError(t, err)
 	assert.NotEmpty(t, a)
-	assert.NotRegexp(t, regexp.MustCompile("^.*\n+$"), a, "should not end in newlines")
+	assert.NotRegexp(t, reNewline, a, "should not end in newlines")
 }
 
 func TestNativeArchitecture(t *testing.T) {
 	a, err := NativeArchitecture()
 	assert.NoError(t, err)
 	assert.NotEmpty(t, a)
-	assert.NotRegexp(t, regexp.MustCompile("^.*\n+$"), a, "should not end in newlines")
+	assert.NotRegexp(t, reNewline, a, "should not end in newlines")
 }


### PR DESCRIPTION
This commit fixes a bug where HostInfo.NativeArchitecture ends in a newline and adds a test.