### PR TITLE
.github/workflows/go.yml - Remove macos-11, add 14

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -36,9 +36,9 @@ jobs:
           - 1.22.x
           - 1.21.x
         os:
-          - macos-11
           - macos-12
           - macos-13
+          - macos-14
           - windows-2019
           - windows-2022
           - ubuntu-20.04
@@ -53,8 +53,8 @@ jobs:
           - {cgo: cgo, os: ubuntu-20.04}
           - {cgo: cgo, os: ubuntu-22.04}
           # Limit the OS variants tested with the earliest supported Go version (save resources).
-          - {go: 1.21.x, os: macos-11}
           - {go: 1.21.x, os: macos-12}
+          - {go: 1.21.x, os: macos-13}
           - {go: 1.21.x, os: windows-2019}
           - {go: 1.21.x, os: ubuntu-22.04}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Remove macos-11 from the test matrix because GitHub removed support for it as of 28 June 2024.

Add macos-14 which tests on arm64 (M1).

Fixes #228