### PR TITLE
Do not lowercase FQDN

### DIFF
--- a/providers/aix/host_aix_ppc64.go
+++ b/providers/aix/host_aix_ppc64.go
@@ -34,7 +34,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/elastic/go-sysinfo/internal/registry"
@@ -191,7 +190,7 @@ func (r *reader) hostname(h *host) {
 	if r.addErr(err) {
 		return
 	}
-	h.info.Hostname = strings.ToLower(v)
+	h.info.Hostname = v
 }
 
 func (r *reader) network(h *host) {

--- a/providers/darwin/host_darwin.go
+++ b/providers/darwin/host_darwin.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/elastic/go-sysinfo/internal/registry"
@@ -226,7 +225,7 @@ func (r *reader) hostname(h *host) {
 	if r.addErr(err) {
 		return
 	}
-	h.info.Hostname = strings.ToLower(v)
+	h.info.Hostname = v
 }
 
 func (r *reader) network(h *host) {

--- a/providers/linux/host_linux.go
+++ b/providers/linux/host_linux.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/prometheus/procfs"
@@ -225,7 +224,7 @@ func (r *reader) hostname(h *host) {
 	if r.addErr(err) {
 		return
 	}
-	h.info.Hostname = strings.ToLower(v)
+	h.info.Hostname = v
 }
 
 func (r *reader) network(h *host) {

--- a/providers/shared/fqdn.go
+++ b/providers/shared/fqdn.go
@@ -51,6 +51,7 @@ func FQDNWithContext(ctx context.Context) (string, error) {
 }
 
 // FQDN just calls FQDNWithContext with a background context.
+// Deprecated.
 func FQDN() (string, error) {
 	return FQDNWithContext(context.Background())
 }
@@ -63,7 +64,7 @@ func fqdn(ctx context.Context, hostname string) (string, error) {
 			err)
 	}
 	if cname != "" {
-		return strings.ToLower(strings.TrimSuffix(cname, ".")), nil
+		return strings.TrimSuffix(cname, "."), nil
 	}
 
 	ips, err := net.DefaultResolver.LookupIP(ctx, "ip", hostname)
@@ -76,7 +77,7 @@ func fqdn(ctx context.Context, hostname string) (string, error) {
 		if err != nil || len(names) == 0 {
 			continue
 		}
-		return strings.ToLower(strings.TrimSuffix(names[0], ".")), nil
+		return strings.TrimSuffix(names[0], "."), nil
 	}
 
 	return "", errs

--- a/providers/shared/fqdn_test.go
+++ b/providers/shared/fqdn_test.go
@@ -36,7 +36,7 @@ func TestFQDN(t *testing.T) {
 		timeout          time.Duration
 	}{
 		// This test case depends on network, particularly DNS,
-		// being available.  If it starts to fail often enough
+		// being available. If it starts to fail often enough
 		// due to occasional network/DNS unavailability, we should
 		// probably just delete this test case.
 		"long_real_hostname": {
@@ -56,7 +56,7 @@ func TestFQDN(t *testing.T) {
 		},
 		"long_mixed_case_hostname": {
 			osHostname:       "eLaSTic.co",
-			expectedFQDN:     "elastic.co",
+			expectedFQDN:     "eLaSTic.co",
 			expectedErrRegex: "",
 		},
 		"nonexistent_timeout": {

--- a/providers/windows/host_windows.go
+++ b/providers/windows/host_windows.go
@@ -89,7 +89,7 @@ func (h *host) FQDNWithContext(_ context.Context) (string, error) {
 		return "", fmt.Errorf("could not get windows FQDN: %s", err)
 	}
 
-	return strings.ToLower(strings.TrimSuffix(fqdn, ".")), nil
+	return strings.TrimSuffix(fqdn, "."), nil
 }
 
 func (h *host) FQDN() (string, error) {
@@ -161,7 +161,7 @@ func (r *reader) hostname(h *host) {
 	if r.addErr(err) {
 		return
 	}
-	h.info.Hostname = strings.ToLower(v)
+	h.info.Hostname = v
 }
 
 func getComputerNameEx(name uint32) (string, error) {

--- a/types/host.go
+++ b/types/host.go
@@ -30,7 +30,7 @@ type Host interface {
 	Info() HostInfo
 	Memory() (*HostMemoryInfo, error)
 
-	// FQDNWithContext returns the fully-qualified domain name of the host, lowercased.
+	// FQDNWithContext returns the fully-qualified domain name of the host.
 	FQDNWithContext(ctx context.Context) (string, error)
 
 	// FQDN calls FQDNWithContext with a background context.
@@ -77,7 +77,7 @@ type HostInfo struct {
 	NativeArchitecture string    `json:"native_architecture"`     // Native OS hardware architecture (e.g. x86_64, arm, ppc, mips).
 	BootTime           time.Time `json:"boot_time"`               // Host boot time.
 	Containerized      *bool     `json:"containerized,omitempty"` // Is the process containerized.
-	Hostname           string    `json:"name"`                    // Hostname, lowercased.
+	Hostname           string    `json:"name"`                    // Hostname.
 	IPs                []string  `json:"ip,omitempty"`            // List of all IPs.
 	KernelVersion      string    `json:"kernel_version"`          // Kernel version.
 	MACs               []string  `json:"mac"`                     // List of MAC addresses.


### PR DESCRIPTION
This PR reverts https://github.com/elastic/go-sysinfo/pull/180

Complying with ECS for `host.name` and `host.hostname` (https://www.elastic.co/guide/en/ecs/current/ecs-host.html#field-host-name) should not be handled by go-sysinfo. The users of go-sysinfo should ensure compliance with ECS if necessary.