### PR TITLE
Update Go toolchains on CI to 1.{22,23}.x

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+env:
+  # Use the local toolchain. Never download.
+  GOTOOLCHAIN: local
+
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -17,7 +21,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
 
       - name: go.mod tidy
         run: go mod tidy && git diff --exit-code
@@ -33,8 +37,8 @@ jobs:
     strategy:
       matrix:
         go:
+          - 1.23.x
           - 1.22.x
-          - 1.21.x
         os:
           - macos-12
           - macos-13
@@ -53,10 +57,10 @@ jobs:
           - {cgo: cgo, os: ubuntu-20.04}
           - {cgo: cgo, os: ubuntu-22.04}
           # Limit the OS variants tested with the earliest supported Go version (save resources).
-          - {go: 1.21.x, os: macos-12}
-          - {go: 1.21.x, os: macos-13}
-          - {go: 1.21.x, os: windows-2019}
-          - {go: 1.21.x, os: ubuntu-22.04}
+          - {go: 1.22.x, os: macos-12}
+          - {go: 1.22.x, os: macos-13}
+          - {go: 1.22.x, os: windows-2019}
+          - {go: 1.22.x, os: ubuntu-22.04}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -99,8 +103,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # Only GITHUB_* are passed into the VM.
-      GITHUB_GOLANG_VERSION: 1.22.2
-    name: test (1.22.2, freebsd-14.0, cgo)
+      GITHUB_GOLANG_VERSION: 1.23.0
+    name: test (1.23.0, freebsd-14.0, cgo)
     steps:
       - uses: actions/checkout@v4
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 Elastic go-sysinfo
-Copyright 2017-2022 Elasticsearch B.V.
+Copyright 2017-2024 Elasticsearch B.V.
 
 This product includes software developed at
 Elasticsearch, B.V. (https://www.elastic.co/).

--- a/README.md
+++ b/README.md
@@ -84,4 +84,4 @@ This table lists the OS and architectures for which a "provider" is implemented.
 
 go-sysinfo supports the [two most recent Go releases][ci_go_versions].
 
-[ci_go_versions]: https://github.com/elastic/go-sysinfo/blob/main/.github/workflows/go.yml#L35-L37
+[ci_go_versions]: https://github.com/elastic/go-sysinfo/blob/main/.github/workflows/go.yml#L40-41


### PR DESCRIPTION
Test with Go 1.23 and 1.22 (the two most recent Go releases).