### PR TITLE
Fetch all ip addresses in a single stdlib call

### DIFF
--- a/.changelog/246.txt
+++ b/.changelog/246.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-Fetch all ip addresses in a single stdlib call
+Fetch all IP addresses in a single stdlib call
 ```

--- a/providers/shared/network.go
+++ b/providers/shared/network.go
@@ -27,9 +27,6 @@ func Network() (ips, macs []string, err error) {
 		return nil, nil, err
 	}
 
-	ips = make([]string, 0, len(ifcs))
-	macs = make([]string, 0, len(ifcs))
-
 	// This function fetches all the addresses in a single syscall. Fetching addresses individually for each interface
 	// can be expensive when the host has a lot of interfaces. This usually happens when the host is doing virtualized
 	// networking for guests, in Kubernetes for example.
@@ -37,10 +34,12 @@ func Network() (ips, macs []string, err error) {
 	if err != nil {
 		return nil, nil, err
 	}
+	ips = make([]string, 0, len(addrs))
 	for _, addr := range addrs {
 		ips = append(ips, addr.String())
 	}
 
+	macs = make([]string, 0, len(ifcs))
 	for _, ifc := range ifcs {
 		mac := ifc.HardwareAddr.String()
 		if mac != "" {


### PR DESCRIPTION
When fetching ip addresses for the host, we fetch all the network interfaces, and then ip addresses for each interface. The latter call is surprisingly expensive on unix, as it involves opening a netlink socket, sending a request for routing information, and receiving and parsing the response. If the host has a lot of network interfaces, this can eat surprising amounts of memory - I got in the order of 10 MB on a Kubernetes Node with 100 Pods. See https://github.com/elastic/elastic-agent/issues/5835#issuecomment-2441544789 for some heap profiles from elastic-agent.

Instead, get all the addresses in a single stdlib call. We don't actually care about which interface each ip address is attached to, we just want all of them.

I've tested this in the real world scenario discussed in https://github.com/elastic/elastic-agent/issues/5835, not sure how to include a self-contained test in this repo.