### PR TITLE
fix linux kernel version string parsing when derermining kernel host architecture

### DIFF
--- a/.changelog/252.txt
+++ b/.changelog/252.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+linux: Improve parsing Linux kernel version for determining native host architecture, x86_64 was not recognized
+```

--- a/providers/linux/arch_linux.go
+++ b/providers/linux/arch_linux.go
@@ -27,6 +27,7 @@ import (
 const (
 	procSysKernelArch = "/proc/sys/kernel/arch"
 	procVersion       = "/proc/version"
+	arch8664          = "x86_64"
 	archAmd64         = "amd64"
 	archArm64         = "arm64"
 	archAarch64       = "aarch64"
@@ -60,14 +61,14 @@ func NativeArchitecture() (string, error) {
 		if os.IsNotExist(err) {
 			// fallback to checking version string for older kernels
 			version, err := os.ReadFile(procVersion)
-			if err != nil {
-				return "", nil
+			if err != nil && !os.IsNotExist(err) {
+				return "", fmt.Errorf("failed to read kernel version: %w", err)
 			}
 
 			versionStr := string(version)
-			if strings.Contains(versionStr, archAmd64) {
+			if strings.Contains(versionStr, archAmd64) || strings.Contains(versionStr, arch8664) {
 				return archAmd64, nil
-			} else if strings.Contains(versionStr, archArm64) {
+			} else if strings.Contains(versionStr, archArm64) || strings.Contains(versionStr, archAarch64) {
 				// for parity with Architecture() and /proc/sys/kernel/arch
 				// as aarch64 and arm64 are used interchangeably
 				return archAarch64, nil


### PR DESCRIPTION
Improve native architecture detection on Linux.

NativeArchitecture() was empty on RedHat with no `/proc/sys/kernel/arch` and `/proc/version`
```
Linux version 5.14.0-547.el9.x86_64 ([mockbuild@x86-05.stream.rdu2.redhat.com](mailto:mockbuild@x86-05.stream.rdu2.redhat.com)) (gcc (GCC) 11.5.0 20240719 (Red Hat 11.5.0-2), GNU ld version 2.35.2-59.el9) #1 SMP PREEMPT_DYNAMIC Mon Dec 30 20:10:38 UTC 2024
```

The fallback of reading `/proc/version` certainly should take into account both synonyms for `AMD64` and `ARM64` architectures.
