### PR TITLE
fix(system_test.go): ignore syscall.EIO when process no longer exists

### DIFF
--- a/system_test.go
+++ b/system_test.go
@@ -324,6 +324,7 @@ func TestProcesses(t *testing.T) {
 			errors.Is(err, syscall.EPERM),
 			errors.Is(err, syscall.EINVAL),
 			errors.Is(err, syscall.ENOENT),
+			errors.Is(err, syscall.EIO),
 			errors.Is(err, fs.ErrPermission):
 			continue
 		case err != nil:


### PR DESCRIPTION
On macOS, proc_pidinfo may return syscall.EIO if the target process has already exited. This change updates the test case to treat EIO as a non-fatal error in cases where the process is likely gone, avoiding flaky test failures due to short-lived PIDs.

Fixes #203