### PR TITLE
Fix AIX compilation issue.

### DIFF
--- a/providers/aix/process_aix_ppc64.go
+++ b/providers/aix/process_aix_ppc64.go
@@ -35,7 +35,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"


### PR DESCRIPTION
This is a PR which fixes the below compile time error in AIX.

providers/aix/process_aix_ppc64.go:38:2: "io/ioutil" imported and not used