### PR TITLE
fix(fqdn): avoid loopback interfaces

### DIFF
--- a/.changelog/269.txt
+++ b/.changelog/269.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`Host.FQDNWithContext()` fixed to not return localhost as FQDN.
+```

--- a/go.mod
+++ b/go.mod
@@ -13,5 +13,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=

--- a/providers/shared/fqdn.go
+++ b/providers/shared/fqdn.go
@@ -27,6 +27,18 @@ import (
 	"strings"
 )
 
+// defaultResolver is the default resolver used by FQDNWithContext.
+// It can be replaced with a custom defaultResolver for testing purposes.
+var defaultResolver resolver = net.DefaultResolver
+
+// defaultResolver is an interface that abstracts the DNS/IP resolution methods used
+// in FQDNWithContext. This allows for easier testing and mocking of DNS lookups.
+type resolver interface {
+	LookupCNAME(ctx context.Context, host string) (string, error)
+	LookupIP(ctx context.Context, network, host string) ([]net.IP, error)
+	LookupAddr(ctx context.Context, addr string) ([]string, error)
+}
+
 // FQDNWithContext attempts to lookup the host's fully-qualified domain name and returns it.
 // It does so using the following algorithm:
 //
@@ -58,7 +70,7 @@ func FQDN() (string, error) {
 
 func fqdn(ctx context.Context, hostname string) (string, error) {
 	var errs error
-	cname, err := net.DefaultResolver.LookupCNAME(ctx, hostname)
+	cname, err := defaultResolver.LookupCNAME(ctx, hostname)
 	if err != nil {
 		errs = fmt.Errorf("could not get FQDN, all methods failed: failed looking up CNAME: %w",
 			err)
@@ -77,17 +89,25 @@ func fqdn(ctx context.Context, hostname string) (string, error) {
 		return cname, nil
 	}
 
-	ips, err := net.DefaultResolver.LookupIP(ctx, "ip", hostname)
+	ips, err := defaultResolver.LookupIP(ctx, "ip", hostname)
 	if err != nil {
 		errs = fmt.Errorf("%s: failed looking up IP: %w", errs, err)
 	}
 
 	for _, ip := range ips {
-		names, err := net.DefaultResolver.LookupAddr(ctx, ip.String())
+		// do not resolve to localhost
+		if ip.IsLoopback() {
+			continue
+		}
+		names, err := defaultResolver.LookupAddr(ctx, ip.String())
 		if err != nil || len(names) == 0 {
 			continue
 		}
 		return strings.TrimSuffix(names[0], "."), nil
+	}
+
+	if errs == nil {
+		return hostname, nil
 	}
 
 	return "", errs

--- a/providers/shared/fqdn.go
+++ b/providers/shared/fqdn.go
@@ -31,7 +31,7 @@ import (
 // It can be replaced with a custom defaultResolver for testing purposes.
 var defaultResolver resolver = net.DefaultResolver
 
-// defaultResolver is an interface that abstracts the DNS/IP resolution methods used
+// resolver is an interface that abstracts the DNS/IP resolution methods used
 // in FQDNWithContext. This allows for easier testing and mocking of DNS lookups.
 type resolver interface {
 	LookupCNAME(ctx context.Context, host string) (string, error)

--- a/providers/shared/fqdn_test.go
+++ b/providers/shared/fqdn_test.go
@@ -23,12 +23,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"net"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
This PR improves the correctness of the `FQDNWithContext` function, which attempts to determine the FQDN of the current host. The main changes are:

- **Avoid returning loopback addresses**: When performing reverse DNS lookups on IPs, the function now skips loopback interfaces (e.g., `127.0.0.1`, `::1`) to avoid returning `localhost` as FQDN.
- **Safe fallback to hostname**: If all DNS-based methods fail but no errors were encountered, the function now safely returns the original hostname.
- **`resolver` Interface**: Introduced a resolver interface to wrap the DNS lookup methods to allow it to be mocked for testing.

Fixes https://github.com/elastic/go-sysinfo/issues/224